### PR TITLE
fix: Apply following filter when loading more polls

### DIFF
--- a/src/components/Feed/PollFeed.tsx
+++ b/src/components/Feed/PollFeed.tsx
@@ -58,6 +58,11 @@ export const PollFeed = () => {
       kinds: [1068],
       until: lastPollEvent?.created_at || Date.now() / 1000,
     };
+
+    if (eventSource === "following" && user?.follows?.length) {
+      filter.authors = user.follows;
+    }
+    
     if (feedSubscritpion) feedSubscritpion.close();
     let newCloser = poolRef.current.subscribeMany(defaultRelays, [filter], {
       onevent: (event) => {


### PR DESCRIPTION
## Summary
Fixes bug where "following" filter wasn't applied when loading more polls, causing all polls to show instead of just followed users' polls.

## Changes
- Added authors filter to load more functionality in `PollFeed.tsx` when eventSource is "following"

## Impact
- Users now see consistent filtering when paginating through following feed

---
*This pull request was created using GitHub Copilot.*