### PR TITLE
fix: Remove nested scrollbars from feeds

### DIFF
--- a/src/components/Feed/NotesFeed/components/FollowingFeed.tsx
+++ b/src/components/Feed/NotesFeed/components/FollowingFeed.tsx
@@ -58,11 +58,11 @@ const FollowingFeed = () => {
       ) : null}
       {loadingMore ? <CircularProgress /> : null}
       <Virtuoso
+        useWindowScroll
         data={mergedNotes}
         itemContent={(index, item) => {
           return <RepostsCard note={item.note} reposts={reposts.get(item.note.id) || []} />
         }}
-        style={{ height: "100vh" }}
         followOutput={false}
         startReached={() => {
           console.log("Top reached!");

--- a/src/components/Feed/NotesFeed/components/ReactedFeed.tsx
+++ b/src/components/Feed/NotesFeed/components/ReactedFeed.tsx
@@ -22,30 +22,29 @@ const ReactedFeed = () => {
   );
 
   return (
-    <div style={{ height: "100vh" }}>
-      <Virtuoso
-        data={sorted}
-        itemContent={(index, note: Event) => (
-          <ReactedNoteCard
-            key={note.id}
-            note={note}
-            reactions={Array.from(reactionEvents.values())}
-          />
-        )}
-        endReached={() => {
-          console.log("Reached bottom, loading more...");
-          fetchReactedNotes();
-        }}
-        components={{
-          Footer: () =>
-            loading ? (
-              <div style={{ textAlign: "center", padding: 20 }}>
-                <CircularProgress size={24} />
-              </div>
-            ) : null,
-        }}
-      />
-    </div>
+    <Virtuoso
+      useWindowScroll
+      data={sorted}
+      itemContent={(index, note: Event) => (
+        <ReactedNoteCard
+          key={note.id}
+          note={note}
+          reactions={Array.from(reactionEvents.values())}
+        />
+      )}
+      endReached={() => {
+        console.log("Reached bottom, loading more...");
+        fetchReactedNotes();
+      }}
+      components={{
+        Footer: () =>
+          loading ? (
+            <div style={{ textAlign: "center", padding: 20 }}>
+              <CircularProgress size={24} />
+            </div>
+          ) : null,
+      }}
+    />
   );
 };
 

--- a/src/components/Feed/PollFeed.tsx
+++ b/src/components/Feed/PollFeed.tsx
@@ -282,35 +282,34 @@ export const PollFeed = () => {
         </Grid>
 
         <Grid size={12}>
-          <div style={{ height: "100vh" }}>
-            {loadingInitial ? (
-              <CenteredBox sx={{ mt: 4 }}>
-                <CircularProgress />
-              </CenteredBox>
-            ) : (
-              <Virtuoso
-                data={combinedEvents}
-                itemContent={(index, event) => (
-                  <div key={event.id}>
-                    <Feed
-                      events={[event]}
-                      userResponses={latestResponses}
-                      reposts={repostsByPollId}
-                    />
-                  </div>
-                )}
-                endReached={loadMore}
-                components={{
-                  Footer: () =>
-                    loadingMore ? (
-                      <CenteredBox sx={{ mt: 2, mb: 2 }}>
-                        <CircularProgress size={24} />
-                      </CenteredBox>
-                    ) : null,
-                }}
-              />
-            )}
-          </div>
+          {loadingInitial ? (
+            <CenteredBox sx={{ mt: 4 }}>
+              <CircularProgress />
+            </CenteredBox>
+          ) : (
+            <Virtuoso
+              useWindowScroll
+              data={combinedEvents}
+              itemContent={(index, event) => (
+                <div key={event.id}>
+                  <Feed
+                    events={[event]}
+                    userResponses={latestResponses}
+                    reposts={repostsByPollId}
+                  />
+                </div>
+              )}
+              endReached={loadMore}
+              components={{
+                Footer: () =>
+                  loadingMore ? (
+                    <CenteredBox sx={{ mt: 2, mb: 2 }}>
+                      <CircularProgress size={24} />
+                    </CenteredBox>
+                  ) : null,
+              }}
+            />
+          )}
         </Grid>
       </Grid>
     </Container>

--- a/src/components/Feed/TopicsFeed/TopicsExplorerFeed.tsx
+++ b/src/components/Feed/TopicsFeed/TopicsExplorerFeed.tsx
@@ -447,9 +447,9 @@ const TopicExplorer: React.FC = () => {
         <Typography>No content found for this topic.</Typography>
       ) : (
         <Virtuoso
+          useWindowScroll
           data={sortedEvents}
           itemContent={itemContent}
-          style={{ height: "100vh" }}
           followOutput={false}
         />
       )}

--- a/src/components/Feed/TopicsFeed/index.tsx
+++ b/src/components/Feed/TopicsFeed/index.tsx
@@ -168,7 +168,6 @@ const TopicsFeed: React.FC = () => {
       sx={{
         px: 2,
         py: 4,
-        height: "100vh",
         display: "flex",
         flexDirection: "column",
       }}
@@ -198,6 +197,7 @@ const TopicsFeed: React.FC = () => {
       ) : (
         <Box sx={{ flexGrow: 1, minHeight: 0 }}>
           <Virtuoso
+            useWindowScroll
             data={tags}
             itemContent={(index, tag) => (
               <TopicCard tag={tag} metadataEvent={metadataMap.get(tag)} />


### PR DESCRIPTION
## Summary
Removes nested scrollbars from feed components by enabling window-based scrolling for all `Virtuoso` lists.

## Changes
- Replaced fixed height and container divs with `useWindowScroll` in all relevant `Virtuoso` components across feed files.

## Impact
- Single, unified scrollbar for feeds.
- Cleaner and more consistent UI.

---
*This pull request was created using GitHub Copilot.*