### PR TITLE
fix(test): make Jest smoke test pass with nostr-tools and MUI polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,13 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^nostr-tools/nip46$": "<rootDir>/node_modules/nostr-tools/lib/cjs/nip46.js",
+      "^@mui/material/styles/useTheme$": "<rootDir>/node_modules/@mui/material/node/styles/useTheme.js",
+      "^react-router/dist$": "<rootDir>/node_modules/react-router/dist/main.js"
+    }
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "@mui/material": "^6.1.2",
     "@mui/styles": "^6.1.2",
     "@mui/x-date-pickers": "^7.17.0",
-    "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^13.4.0",
-    "@types/jest": "^27.5.2",
     "@types/node": "^16.18.101",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -73,6 +70,9 @@
     ]
   },
   "devDependencies": {
-    "@capacitor/assets": "^3.0.5"
+    "@capacitor/assets": "^3.0.5",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^13.4.0",
+    "@types/jest": "^27.5.2"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,25 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+jest.mock("./hooks/useMiningWorker", () => ({
+  useMiningWorker: () => ({
+    minePow: jest.fn(),
+    isCompleted: false,
+    cancelMining: jest.fn(),
+    progress: { maxDifficultyAchieved: 0, numHashes: 0 },
+  }),
+}));
+
+jest.mock("nostr-signer-capacitor-plugin", () => ({
+  NostrSignerPlugin: {
+    getInstalledSignerApps: () => Promise.resolve({ apps: [] }),
+  },
+}));
+
+test("shows Pollerama header", async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(
+    await screen.findByRole("heading", { name: /pollerama/i }),
+  ).toBeInTheDocument();
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,18 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(globalThis, { TextDecoder, TextEncoder });
+
+window.matchMedia = function matchMedia(query: string): MediaQueryList {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  } as MediaQueryList;
+};
+
+import "@testing-library/jest-dom";


### PR DESCRIPTION
Jest was failing on a fresh run: nostr-tools needs TextEncoder/TextDecoder in this environment, MUI expects matchMedia, and a few imports resolve to ESM that Jest does not handle out of the box. Added small polyfills in setupTests.ts and a few moduleNameMapper entries in package.json.

The old CRA “learn react” test did not match this app. It now renders App and checks for the Pollerama heading, with mocks for the mining worker and nostr-signer-capacitor-plugin so the tree can mount in jsdom without errors.

Baseline for adding real tests in a follow-up PR.

Before:
<img width="606" height="334" alt="Screenshot 2026-04-05 at 6 05 11 PM" src="https://github.com/user-attachments/assets/b2f42772-599c-4c3f-9fc1-b193c0101772" />

After:
<img width="678" height="159" alt="Screenshot 2026-04-05 at 6 04 32 PM" src="https://github.com/user-attachments/assets/838d6994-4bf8-4994-a1a2-0823733060f6" />

