### PR TITLE
test: add poll event, tally and rendering tests

### DIFF
--- a/src/components/EventCreator/PollTemplateForm.tsx
+++ b/src/components/EventCreator/PollTemplateForm.tsx
@@ -34,8 +34,8 @@ import { useNotification } from "../../contexts/notification-context";
 import { useUserContext } from "../../hooks/useUserContext";
 import { useNavigate } from "react-router-dom";
 import { NOTIFICATION_MESSAGES } from "../../constants/notifications";
-import { NOSTR_EVENT_KINDS } from "../../constants/nostr";
 import { signEvent } from "../../nostr";
+import { buildUnsignedPollEvent } from "../../utils/pollEvent";
 import { useRelays } from "../../hooks/useRelays";
 import { PollPreview } from "./PollPreview";
 import { Event, nip19 } from "nostr-tools";
@@ -212,22 +212,17 @@ const PollTemplateForm: React.FC<{
       }
 
       const mentionTags = extractMentionTags(eventContent);
-      const pollEvent = {
-        kind: NOSTR_EVENT_KINDS.POLL,
+      const pollEvent = buildUnsignedPollEvent({
         content: finalContent,
-        tags: [
-          ...options.map((option: Option) => ["option", option[0], option[1]]),
-          ...relays.map((relay) => ["relay", relay]),
-          ...topics.map((tag) => ["t", tag]),
-          ...mentionTags,
-          ...quoteTags,
-        ],
-        created_at: Math.floor(Date.now() / 1000),
-      };
-
-      if (poW) pollEvent.tags.push(["PoW", poW.toString()]);
-      if (pollType) pollEvent.tags.push(["polltype", pollType]);
-      if (expiration) pollEvent.tags.push(["endsAt", expiration.toString()]);
+        options,
+        relays,
+        topics,
+        mentionTags,
+        quoteTags,
+        poW,
+        pollType,
+        expiration,
+      });
 
       setIsSubmitting(true);
       const signedEvent = await signEvent(pollEvent, user?.privateKey);

--- a/src/components/PollResponse/PollResponseForm.test.tsx
+++ b/src/components/PollResponse/PollResponseForm.test.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import type { Event } from "nostr-tools";
+import PollResponseForm from "./PollResponseForm";
+
+jest.mock("../../nostr", () => ({
+  signEvent: jest.fn(),
+  openProfileTab: jest.fn(),
+}));
+
+jest.mock("../../singletons", () => ({
+  pool: { publish: jest.fn() },
+}));
+
+jest.mock("../Common/Parsers/TextWithImages", () => ({
+  TextWithImages: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+jest.mock("../Common/Nip05Badge", () => ({
+  Nip05Badge: () => null,
+}));
+
+jest.mock("../FeedbackMenu", () => ({
+  FeedbackMenu: () => null,
+}));
+
+jest.mock("../../hooks/usePollResults", () => ({
+  usePollResults: () => ({ results: new Map() }),
+}));
+
+jest.mock("../../hooks/useEventRelays", () => ({
+  useEventRelays: () => [],
+}));
+
+jest.mock("../../hooks/useReports", () => ({
+  useReports: () => ({
+    reportEvent: jest.fn(),
+    reportUser: jest.fn(),
+    isReportedByMe: () => false,
+    getWoTReporters: () => new Set<string>(),
+    wotReportThreshold: 0,
+    requestUserReportCheck: jest.fn(),
+  }),
+}));
+
+jest.mock("../../hooks/usePublishDiagnostic", () => ({
+  usePublishDiagnostic: () => ({
+    result: null,
+    open: false,
+    setOpen: jest.fn(),
+    title: "",
+    openModal: jest.fn(),
+    retry: jest.fn(),
+  }),
+}));
+
+jest.mock("../../hooks/useMiningWorker", () => ({
+  useMiningWorker: () => ({
+    minePow: jest.fn(),
+    cancelMining: jest.fn(),
+    progress: { maxDifficultyAchieved: 0, numHashes: 0 },
+  }),
+}));
+
+jest.mock("../../hooks/useBackClose", () => ({
+  useBackClose: jest.fn(),
+}));
+
+jest.mock("../../hooks/useRelays", () => ({
+  useRelays: () => ({ relays: [], writeRelays: [] }),
+}));
+
+jest.mock("../../hooks/useListContext", () => ({
+  useListContext: () => ({ fetchLatestContactList: jest.fn() }),
+}));
+
+jest.mock("../../hooks/useUserContext", () => ({
+  useUserContext: () => ({
+    user: null,
+    setUser: jest.fn(),
+    requestLogin: jest.fn(),
+  }),
+}));
+
+jest.mock("../../hooks/useAppContext", () => ({
+  useAppContext: () => ({
+    profiles: new Map(),
+    fetchUserProfileThrottled: jest.fn(),
+  }),
+}));
+
+jest.mock("../../contexts/notification-context", () => ({
+  useNotification: () => ({ showNotification: jest.fn() }),
+}));
+
+const theme = createTheme();
+
+function renderPoll(pollEvent: Event) {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <PollResponseForm pollEvent={pollEvent} />
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("PollResponseForm", () => {
+  it("renders poll title (content) and all option labels", () => {
+    const pollEvent: Event = {
+      kind: 1068,
+      id: "bb".repeat(32),
+      pubkey: "aa".repeat(32),
+      content: "Which runtime do you prefer?",
+      tags: [
+        ["option", "opt-node", "Node.js"],
+        ["option", "opt-bun", "Bun"],
+        ["option", "opt-deno", "Deno"],
+        ["polltype", "singlechoice"],
+      ],
+      sig: "cc".repeat(64),
+      created_at: 1_700_000_000,
+    };
+
+    renderPoll(pollEvent);
+
+    expect(
+      screen.getByText("Which runtime do you prefer?")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Node.js")).toBeInTheDocument();
+    expect(screen.getByText("Bun")).toBeInTheDocument();
+    expect(screen.getByText("Deno")).toBeInTheDocument();
+  });
+
+  it("uses label tag over content when present", () => {
+    const pollEvent: Event = {
+      kind: 1068,
+      id: "dd".repeat(32),
+      pubkey: "ee".repeat(32),
+      content: "ignored body",
+      tags: [
+        ["label", "Shown title from label tag"],
+        ["option", "x", "Only option"],
+        ["polltype", "singlechoice"],
+      ],
+      sig: "ff".repeat(64),
+      created_at: 1,
+    };
+
+    renderPoll(pollEvent);
+
+    expect(
+      screen.getByText("Shown title from label tag")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("ignored body")).not.toBeInTheDocument();
+    expect(screen.getByText("Only option")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/usePollResults.ts
+++ b/src/hooks/usePollResults.ts
@@ -1,15 +1,12 @@
 import { useEffect, useRef, useMemo, useState } from "react";
 import { Event, Filter } from "nostr-tools";
-import { nip13 } from "nostr-tools";
 import { nostrRuntime } from "../singletons";
 import { SubscriptionHandle } from "../nostrRuntime/types";
 import { useRelays } from "./useRelays";
+import { dedupeVoteEvents, tallyPollResults } from "../utils/pollTally";
+import type { OptionResult } from "../utils/pollTally";
 
-export interface OptionResult {
-  count: number;
-  percentage: number;
-  responders: string[];
-}
+export type { OptionResult } from "../utils/pollTally";
 
 /**
  * Subscribes to vote events for a poll and returns per-option results.
@@ -60,50 +57,15 @@ export function usePollResults(
     };
   }, [enabled, pollEvent.id, pollEvent.tags, difficulty, filterPubkeys, userRelays]);
 
-  const options = useMemo(
-    () => pollEvent.tags.filter((t) => t[0] === "option"),
-    [pollEvent.tags]
+  const uniqueResponses = useMemo(
+    () => dedupeVoteEvents(responses, difficulty),
+    [responses, difficulty]
   );
 
-  // Deduplicate: keep only the latest valid response per pubkey
-  const uniqueResponses = useMemo(() => {
-    const map = new Map<string, Event>();
-    for (const event of responses) {
-      if (difficulty && nip13.getPow(event.id) < difficulty) continue;
-      const existing = map.get(event.pubkey);
-      if (!existing || event.created_at > existing.created_at) {
-        map.set(event.pubkey, event);
-      }
-    }
-    return Array.from(map.values());
-  }, [responses, difficulty]);
-
-  const results = useMemo(() => {
-    const counts = new Map<string, { count: number; responders: string[] }>();
-    for (const opt of options) counts.set(opt[1], { count: 0, responders: [] });
-
-    for (const event of uniqueResponses) {
-      for (const tag of event.tags) {
-        if (tag[0] === "response") {
-          const entry = counts.get(tag[1]);
-          if (entry && !entry.responders.includes(event.pubkey)) {
-            entry.count++;
-            entry.responders.push(event.pubkey);
-          }
-        }
-      }
-    }
-
-    const total = Array.from(counts.values()).reduce((s, v) => s + v.count, 0);
-    const out = new Map<string, OptionResult>();
-    Array.from(counts.entries()).forEach(([id, v]) => {
-      out.set(id, {
-        ...v,
-        percentage: total > 0 ? (v.count / total) * 100 : 0,
-      });
-    });
-    return out;
-  }, [uniqueResponses, options]);
+  const results = useMemo(
+    () => tallyPollResults(pollEvent.tags, uniqueResponses),
+    [uniqueResponses, pollEvent.tags]
+  );
 
   return { results, totalVotes: uniqueResponses.length };
 }

--- a/src/utils/pollEvent.test.ts
+++ b/src/utils/pollEvent.test.ts
@@ -1,0 +1,88 @@
+import { NOSTR_EVENT_KINDS } from "../constants/nostr";
+import type { Option } from "../interfaces";
+import { buildUnsignedPollEvent } from "./pollEvent";
+
+describe("buildUnsignedPollEvent", () => {
+  it("tags include all provided options, relays, topics, and mentions", () => {
+    const options: Option[] = [
+      ["opt-a", "Red"],
+      ["opt-b", "Blue"],
+    ];
+    const evt = buildUnsignedPollEvent({
+      content: "Pick a color",
+      options,
+      relays: ["wss://relay.example.com"],
+      topics: ["colors"],
+      mentionTags: [["p", "ab".repeat(32)]],
+      quoteTags: [],
+      createdAt: 1_700_000_000,
+    });
+
+    expect(evt.kind).toBe(NOSTR_EVENT_KINDS.POLL);
+    expect(evt.content).toBe("Pick a color");
+    expect(evt.created_at).toBe(1_700_000_000);
+
+    expect(evt.tags.filter((t) => t[0] === "option")).toHaveLength(2);
+    expect(evt.tags).toContainEqual(["option", "opt-a", "Red"]);
+    expect(evt.tags).toContainEqual(["option", "opt-b", "Blue"]);
+    expect(evt.tags).toContainEqual(["relay", "wss://relay.example.com"]);
+    expect(evt.tags).toContainEqual(["t", "colors"]);
+    expect(evt.tags).toContainEqual(["p", "ab".repeat(32)]);
+  });
+
+  it("appends PoW, polltype, and endsAt when provided", () => {
+    const evt = buildUnsignedPollEvent({
+      content: "Q",
+      options: [["1", "A"]],
+      relays: [],
+      topics: [],
+      mentionTags: [],
+      quoteTags: [],
+      poW: 16,
+      pollType: "singlechoice",
+      expiration: 1_700_000_100,
+      createdAt: 10,
+    });
+
+    expect(evt.tags).toContainEqual(["PoW", "16"]);
+    expect(evt.tags).toContainEqual(["polltype", "singlechoice"]);
+    expect(evt.tags).toContainEqual(["endsAt", "1700000100"]);
+  });
+
+  it("omits optional tags when PoW / polltype / expiration are absent", () => {
+    const evt = buildUnsignedPollEvent({
+      content: "Plain",
+      options: [["x", "Yes"]],
+      relays: [],
+      topics: [],
+      mentionTags: [],
+      quoteTags: [],
+      poW: null,
+      pollType: null,
+      expiration: null,
+    });
+
+    expect(evt.tags.some((t) => t[0] === "PoW")).toBe(false);
+    expect(evt.tags.some((t) => t[0] === "polltype")).toBe(false);
+    expect(evt.tags.some((t) => t[0] === "endsAt")).toBe(false);
+  });
+
+  it("merges quote tags from the publishing form", () => {
+    const quotedId = "cd".repeat(32);
+    const evt = buildUnsignedPollEvent({
+      content: "See quote",
+      options: [["o", "OK"]],
+      relays: ["wss://r1"],
+      topics: [],
+      mentionTags: [],
+      quoteTags: [
+        ["q", quotedId, "wss://r1"],
+        ["p", "ef".repeat(32)],
+      ],
+      createdAt: 42,
+    });
+
+    expect(evt.tags).toContainEqual(["q", quotedId, "wss://r1"]);
+    expect(evt.tags).toContainEqual(["p", "ef".repeat(32)]);
+  });
+});

--- a/src/utils/pollEvent.ts
+++ b/src/utils/pollEvent.ts
@@ -1,0 +1,62 @@
+import { NOSTR_EVENT_KINDS } from "../constants/nostr";
+import type { Option } from "../interfaces";
+
+export type UnsignedPollEventTemplate = {
+  kind: number;
+  content: string;
+  tags: string[][];
+  created_at: number;
+};
+
+export type BuildUnsignedPollEventParams = {
+  content: string;
+  options: Option[];
+  relays: string[];
+  topics: string[];
+  mentionTags: string[][];
+  quoteTags: string[][];
+  poW?: number | null;
+  pollType?: string | null;
+  expiration?: number | null;
+  createdAt?: number;
+};
+
+/**
+ * Builds the unsigned poll event template used before signing (kind 1068).
+ * Mirrors {@link PollTemplateForm} publish payload shape.
+ */
+export function buildUnsignedPollEvent(
+  params: BuildUnsignedPollEventParams
+): UnsignedPollEventTemplate {
+  const {
+    content,
+    options,
+    relays,
+    topics,
+    mentionTags,
+    quoteTags,
+    poW,
+    pollType,
+    expiration,
+    createdAt = Math.floor(Date.now() / 1000),
+  } = params;
+
+  const pollEvent: UnsignedPollEventTemplate = {
+    kind: NOSTR_EVENT_KINDS.POLL,
+    content,
+    tags: [
+      ...options.map((option) => ["option", option[0], option[1]] as string[]),
+      ...relays.map((relay) => ["relay", relay] as string[]),
+      ...topics.map((tag) => ["t", tag] as string[]),
+      ...mentionTags,
+      ...quoteTags,
+    ],
+    created_at: createdAt,
+  };
+
+  if (poW) pollEvent.tags.push(["PoW", poW.toString()]);
+  if (pollType) pollEvent.tags.push(["polltype", pollType]);
+  if (expiration) pollEvent.tags.push(["endsAt", expiration.toString()]);
+
+  return pollEvent;
+}

--- a/src/utils/pollTally.test.ts
+++ b/src/utils/pollTally.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable import/first -- jest.mock must run before imports that use the mocked module */
+jest.mock("nostr-tools", () => {
+  const actual = jest.requireActual<typeof import("nostr-tools")>(
+    "nostr-tools"
+  );
+  return {
+    ...actual,
+    nip13: {
+      ...actual.nip13,
+      getPow: jest.fn((id: string) => actual.nip13.getPow(id)),
+    },
+  };
+});
+
+import type { Event } from "nostr-tools";
+import { nip13 } from "nostr-tools";
+import {
+  dedupeVoteEvents,
+  leadingOptionIds,
+  tallyPollResults,
+} from "./pollTally";
+
+const pollTags: string[][] = [
+  ["option", "a", "Alpha"],
+  ["option", "b", "Bravo"],
+  ["option", "c", "Charlie"],
+];
+
+function voteEvent(params: {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  selected: string[];
+}): Event {
+  const { id, pubkey, created_at, selected } = params;
+  return {
+    id,
+    pubkey,
+    kind: 1018,
+    content: "",
+    created_at,
+    sig: "00",
+    tags: [
+      ["e", "aa".repeat(64)],
+      ["p", "bb".repeat(64)],
+      ...selected.map((s) => ["response", s] as string[]),
+    ],
+  };
+}
+
+const getPowMock = nip13.getPow as jest.MockedFunction<typeof nip13.getPow>;
+
+beforeEach(() => {
+  const actual = jest.requireActual<typeof import("nostr-tools")>(
+    "nostr-tools"
+  );
+  getPowMock.mockImplementation((id) => actual.nip13.getPow(id));
+});
+
+describe("tallyPollResults", () => {
+  it("counts votes per option and picks a single winner", () => {
+    const votes = [
+      voteEvent({
+        id: "11".repeat(32),
+        pubkey: "aa".repeat(32),
+        created_at: 1,
+        selected: ["a"],
+      }),
+      voteEvent({
+        id: "22".repeat(32),
+        pubkey: "bb".repeat(32),
+        created_at: 2,
+        selected: ["a"],
+      }),
+      voteEvent({
+        id: "33".repeat(32),
+        pubkey: "cc".repeat(32),
+        created_at: 3,
+        selected: ["b"],
+      }),
+    ];
+
+    const unique = dedupeVoteEvents(votes, 0);
+    const results = tallyPollResults(pollTags, unique);
+
+    expect(results.get("a")?.count).toBe(2);
+    expect(results.get("b")?.count).toBe(1);
+    expect(results.get("c")?.count).toBe(0);
+    expect(leadingOptionIds(results)).toEqual(["a"]);
+
+    expect(results.get("a")?.percentage).toBeCloseTo(66.67, 1);
+    expect(results.get("b")?.percentage).toBeCloseTo(33.33, 1);
+  });
+
+  it("handles multiple selections on one vote (multiple-choice style)", () => {
+    const votes = [
+      voteEvent({
+        id: "44".repeat(32),
+        pubkey: "dd".repeat(32),
+        created_at: 1,
+        selected: ["a", "c"],
+      }),
+    ];
+
+    const unique = dedupeVoteEvents(votes, 0);
+    const results = tallyPollResults(pollTags, unique);
+
+    expect(results.get("a")?.count).toBe(1);
+    expect(results.get("c")?.count).toBe(1);
+    expect(results.get("b")?.count).toBe(0);
+    expect(leadingOptionIds(results).sort()).toEqual(["a", "c"]);
+  });
+
+  it("uses the latest vote when a user re-votes for a different option", () => {
+    const votes = [
+      voteEvent({
+        id: "77".repeat(32),
+        pubkey: "ff".repeat(32),
+        created_at: 1,
+        selected: ["a"],
+      }),
+      voteEvent({
+        id: "88".repeat(32),
+        pubkey: "ff".repeat(32),
+        created_at: 2,
+        selected: ["b"],
+      }),
+    ];
+
+    const unique = dedupeVoteEvents(votes, 0);
+    expect(unique).toHaveLength(1);
+    const results = tallyPollResults(pollTags, unique);
+    expect(results.get("a")?.count).toBe(0);
+    expect(results.get("b")?.count).toBe(1);
+  });
+
+  it("does not double-count the same option from the same pubkey", () => {
+    const votes = [
+      voteEvent({
+        id: "55".repeat(32),
+        pubkey: "ee".repeat(32),
+        created_at: 1,
+        selected: ["b"],
+      }),
+      voteEvent({
+        id: "66".repeat(32),
+        pubkey: "ee".repeat(32),
+        created_at: 2,
+        selected: ["b"],
+      }),
+    ];
+
+    const unique = dedupeVoteEvents(votes, 0);
+    expect(unique).toHaveLength(1);
+    const results = tallyPollResults(pollTags, unique);
+    expect(results.get("b")?.count).toBe(1);
+    expect(results.get("b")?.responders).toEqual(["ee".repeat(32)]);
+  });
+});
+
+describe("dedupeVoteEvents", () => {
+  it("drops votes that do not meet PoW difficulty when set", () => {
+    const low = voteEvent({
+      id: "aa".repeat(32),
+      pubkey: "11".repeat(32),
+      created_at: 1,
+      selected: ["a"],
+    });
+    const high = voteEvent({
+      id: "bb".repeat(32),
+      pubkey: "22".repeat(32),
+      created_at: 1,
+      selected: ["b"],
+    });
+
+    getPowMock.mockImplementation((id: string) =>
+      id === "aa".repeat(32) ? 5 : 20
+    );
+
+    const unique = dedupeVoteEvents([low, high], 10);
+    expect(unique).toHaveLength(1);
+    expect(unique[0].pubkey).toBe("22".repeat(32));
+  });
+});

--- a/src/utils/pollTally.ts
+++ b/src/utils/pollTally.ts
@@ -1,0 +1,75 @@
+import type { Event } from "nostr-tools";
+import { nip13 } from "nostr-tools";
+
+export interface OptionResult {
+  count: number;
+  percentage: number;
+  responders: string[];
+}
+
+/**
+ * Keeps the latest valid vote per pubkey, optionally filtering by PoW difficulty on the vote id.
+ */
+export function dedupeVoteEvents(
+  responses: Event[],
+  difficulty: number
+): Event[] {
+  const map = new Map<string, Event>();
+  for (const event of responses) {
+    if (difficulty && nip13.getPow(event.id) < difficulty) continue;
+    const existing = map.get(event.pubkey);
+    if (!existing || event.created_at > existing.created_at) {
+      map.set(event.pubkey, event);
+    }
+  }
+  return Array.from(map.values());
+}
+
+/**
+ * Tallies `response` tags from deduplicated vote events against poll `option` tags.
+ */
+export function tallyPollResults(
+  pollTags: string[][],
+  uniqueResponses: Event[]
+): Map<string, OptionResult> {
+  const options = pollTags.filter((t) => t[0] === "option");
+  const counts = new Map<string, { count: number; responders: string[] }>();
+  for (const opt of options) counts.set(opt[1], { count: 0, responders: [] });
+
+  for (const event of uniqueResponses) {
+    for (const tag of event.tags) {
+      if (tag[0] === "response") {
+        const entry = counts.get(tag[1]);
+        if (entry && !entry.responders.includes(event.pubkey)) {
+          entry.count++;
+          entry.responders.push(event.pubkey);
+        }
+      }
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, v) => s + v.count, 0);
+  const out = new Map<string, OptionResult>();
+  Array.from(counts.entries()).forEach(([id, v]) => {
+    out.set(id, {
+      ...v,
+      percentage: total > 0 ? (v.count / total) * 100 : 0,
+    });
+  });
+  return out;
+}
+
+/** Option id(s) with the highest vote count (ties preserved). */
+export function leadingOptionIds(
+  results: Map<string, OptionResult>
+): string[] {
+  const values = Array.from(results.values());
+  let max = 0;
+  for (let i = 0; i < values.length; i++) {
+    max = Math.max(max, values[i].count);
+  }
+  if (max === 0) return [];
+  return Array.from(results.entries())
+    .filter(([, r]) => r.count === max)
+    .map(([id]) => id);
+}


### PR DESCRIPTION
nostr-polls had no tests beyond the default CRA placeholder. This PR adds meaningful test coverage across three areas:

**Poll event construction:** verifies kind 1068 is used and that options, relays, topics and mentions are wired into the correct tag positions.

**Vote tally logic:** covers standard tallying, duplicate vote deduplication, and the re-vote case where a user changes their choice and the latest created_at wins. Percentages are asserted directly rather than just checking they sum to 100.

**Poll rendering:** mounts PollResponseForm with a mock poll event and verifies options appear in the DOM.

Mock ids and pubkeys use 64-character hex strings (32 bytes). sig uses 128-character hex where required.

4 suites, 12 tests, all passing.
<img width="696" height="198" alt="Screenshot 2026-04-06 at 5 33 56 PM" src="https://github.com/user-attachments/assets/d6dd3df4-f6ca-42ea-926f-54b80f784666" />
