### PR TITLE
fix: restore tab favicon using existing logo asset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <link rel="icon" type="image/png" href="%PUBLIC_URL%/logo192.png" />
+  <link rel="shortcut icon" href="%PUBLIC_URL%/logo192.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Polls On Nostr!" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.svg" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <title>Pollerama</title>
 


### PR DESCRIPTION
@abh3po @geralt-debugs 
the favicon url was not pointing to the correct asset 
Before:

<img width="334" height="51" alt="Screenshot 2026-04-12 021900" src="https://github.com/user-attachments/assets/fcc8d1ea-8026-44fe-8d9d-6cfd876c7173" />

After:
<img width="303" height="55" alt="Screenshot 2026-04-12 030531" src="https://github.com/user-attachments/assets/65f66a12-5e48-4837-b613-3b33c9b0a629" />
