### PR TITLE
adds mixed polls/notes feed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import EventList from "./components/Feed/FeedsLayout";
 import NotesFeed from "./components/Feed/NotesFeed/components";
 import ProfilesFeed from "./components/Feed/ProfileFeed";
 import { PollFeed } from "./components/Feed/PollFeed";
+import MixedFeed from "./components/Feed/MixedFeed";
 import MoviesFeed from "./components/Feed/MoviesFeed";
 import FollowPacksFeed from "./components/Feed/FollowPacksFeed";
 import FollowPackDetail from "./components/FollowPacks/FollowPackDetail";
@@ -155,6 +156,7 @@ function AppContent() {
           <Route path="/ratings" element={<EventList />} />
 
           <Route path="/feeds" element={<FeedsLayout />}>
+            <Route path="all" element={<MixedFeed />} />
             <Route path="notes" element={<NotesFeed />} />
             <Route path="profiles" element={<ProfilesFeed />} />
             <Route path="topics" element={<TopicsFeed />}>

--- a/src/components/Feed/MixedFeed.tsx
+++ b/src/components/Feed/MixedFeed.tsx
@@ -1,0 +1,337 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box } from "@mui/material";
+import { Event, Filter, verifyEvent } from "nostr-tools";
+import { useUserContext } from "../../hooks/useUserContext";
+import { useRelays } from "../../hooks/useRelays";
+import { useSubNav } from "../../contexts/SubNavContext";
+import { useFeedActions } from "../../contexts/FeedActionsContext";
+import { useReports } from "../../hooks/useReports";
+import { nostrRuntime } from "../../singletons";
+import { SubscriptionHandle } from "../../nostrRuntime/types";
+import { getRelaysForAuthors, prefetchOutboxRelays } from "../../nostr/OutboxService";
+import UnifiedFeed from "./UnifiedFeed";
+import PollResponseForm from "../PollResponse/PollResponseForm";
+import { Notes } from "../Notes";
+
+const KIND_NOTE = 1;
+const KIND_POLL = 1068;
+const MIXED_SOURCE_KEY = "pollerama:mixedSource";
+const INITIAL_BATCH_SIZE = 40;
+const PAGE_BATCH_SIZE = 20;
+
+type MixedSource = "global" | "following" | "webOfTrust";
+
+const isRootNote = (event: Event) => !event.tags.some((t) => t[0] === "e");
+
+const isDisplayable = (event: Event) =>
+  event.kind === KIND_POLL || (event.kind === KIND_NOTE && isRootNote(event));
+
+const mergeEvents = (existing: Event[], incoming: Event[]): Event[] => {
+  const map = new Map(existing.map((e) => [e.id, e]));
+  for (const event of incoming) {
+    map.set(event.id, event);
+  }
+  return Array.from(map.values()).sort((a, b) => b.created_at - a.created_at);
+};
+
+const MixedFeedItem = React.memo(({ event }: { event: Event }) => {
+  if (event.kind === KIND_POLL) {
+    return (
+      <Box sx={{ my: "20px", mx: { xs: 0, sm: "auto" }, width: "100%", maxWidth: { xs: "100%", sm: "600px" } }}>
+        <PollResponseForm pollEvent={event} />
+      </Box>
+    );
+  }
+
+  return <Notes event={event} />;
+});
+
+export const MixedFeed: React.FC = () => {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [pendingEvents, setPendingEvents] = useState<Event[]>([]);
+  const [eventSource, setEventSource] = useState<MixedSource>(() => {
+    const saved = localStorage.getItem(MIXED_SOURCE_KEY);
+    return saved === "following" || saved === "webOfTrust" ? saved : "global";
+  });
+  const [feedSubscription, setFeedSubscription] = useState<SubscriptionHandle | undefined>();
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const loadingInitialRef = useRef(true);
+  const oldestNoteTimestampRef = useRef<number | null>(null);
+  const oldestPollTimestampRef = useRef<number | null>(null);
+
+  const { user } = useUserContext();
+  const { relays } = useRelays();
+  const { setItems, clearItems } = useSubNav();
+  const { registerRefresh } = useFeedActions();
+  const { requestReportCheck, requestUserReportCheck } = useReports();
+
+  useEffect(() => {
+    loadingInitialRef.current = loadingInitial;
+  }, [loadingInitial]);
+
+  useEffect(() => {
+    localStorage.setItem(MIXED_SOURCE_KEY, eventSource);
+    setItems([
+      {
+        key: "global",
+        label: "Global",
+        active: eventSource === "global",
+        onClick: () => setEventSource("global"),
+      },
+      {
+        key: "following",
+        label: "Following",
+        active: eventSource === "following",
+        onClick: () => setEventSource("following"),
+        disabled: !user || !user.follows?.length,
+      },
+      {
+        key: "webOfTrust",
+        label: "Web of Trust",
+        active: eventSource === "webOfTrust",
+        onClick: () => setEventSource("webOfTrust"),
+        disabled: !user || !user.webOfTrust || !user.webOfTrust.size,
+      },
+    ]);
+
+    return () => clearItems();
+  }, [eventSource, user, setItems, clearItems]);
+
+  const getSourceFilters = useCallback(
+    (filters: Filter[]) => {
+      const nextFilters: Filter[] = filters.map((filter) => ({ ...filter }));
+      let relayOverride: string[] | undefined;
+
+      if (eventSource === "following" && user?.follows?.length) {
+        const authors = user.follows;
+        nextFilters.forEach((filter) => {
+          filter.authors = authors;
+        });
+        prefetchOutboxRelays(authors);
+        relayOverride = getRelaysForAuthors(relays, authors);
+      }
+
+      if (eventSource === "webOfTrust" && user?.webOfTrust?.size) {
+        const authors = Array.from(user.webOfTrust);
+        nextFilters.forEach((filter) => {
+          filter.authors = authors;
+        });
+        prefetchOutboxRelays(authors);
+        relayOverride = getRelaysForAuthors(relays, authors);
+      }
+
+      return { filters: nextFilters, relayOverride };
+    },
+    [eventSource, user, relays]
+  );
+
+  const handleIncomingEvent = useCallback((event: Event) => {
+    if (!verifyEvent(event) || !isDisplayable(event)) return;
+    if (loadingInitialRef.current) {
+      setEvents((prev) => mergeEvents(prev, [event]));
+      return;
+    }
+    setPendingEvents((prev) => mergeEvents(prev, [event]));
+  }, []);
+
+  const subscribe = useCallback(
+    (
+      filters: Filter[],
+      options?: {
+        onEose?: () => void;
+        fresh?: boolean;
+      }
+    ) => {
+      const { filters: sourceFilters, relayOverride } = getSourceFilters(filters);
+      return nostrRuntime.subscribe(relayOverride ?? relays, sourceFilters, {
+        onEvent: handleIncomingEvent,
+        onEose: options?.onEose,
+        fresh: options?.fresh,
+      });
+    },
+    [getSourceFilters, relays, handleIncomingEvent]
+  );
+
+  const buildFilters = useCallback(
+    (kind: "initial" | "older" | "newer") => {
+      const now = Math.floor(Date.now() / 1000);
+      const noteFilter: Filter = {
+        kinds: [KIND_NOTE],
+        limit: kind === "initial" ? INITIAL_BATCH_SIZE : PAGE_BATCH_SIZE,
+      };
+      const pollFilter: Filter = {
+        kinds: [KIND_POLL],
+        limit: kind === "initial" ? INITIAL_BATCH_SIZE : PAGE_BATCH_SIZE,
+      };
+
+      if (kind === "initial") {
+        noteFilter.since = now - 86400;
+        pollFilter.since = now - 86400;
+      } else if (kind === "older") {
+        if (oldestNoteTimestampRef.current != null) {
+          noteFilter.until = oldestNoteTimestampRef.current;
+        }
+        if (oldestPollTimestampRef.current != null) {
+          pollFilter.until = oldestPollTimestampRef.current;
+        }
+      } else {
+        const newestNote = events
+          .filter((event) => event.kind === KIND_NOTE)
+          .reduce<number | null>((latest, event) => {
+            return latest == null || event.created_at > latest ? event.created_at : latest;
+          }, null);
+        const newestPoll = events
+          .filter((event) => event.kind === KIND_POLL)
+          .reduce<number | null>((latest, event) => {
+            return latest == null || event.created_at > latest ? event.created_at : latest;
+          }, null);
+
+        if (newestNote != null) {
+          noteFilter.since = newestNote + 1;
+        }
+        if (newestPoll != null) {
+          pollFilter.since = newestPoll + 1;
+        }
+      }
+
+      return [noteFilter, pollFilter];
+    },
+    [events]
+  );
+
+  const fetchInitial = useCallback(
+    (fresh?: boolean) => {
+      const handle = subscribe(
+        buildFilters("initial"),
+        {
+          fresh,
+          onEose: () => {
+            if (fresh) {
+              setRefreshing(false);
+              loadingInitialRef.current = false;
+            } else {
+              setLoadingInitial(false);
+            }
+          },
+        }
+      );
+      return handle;
+    },
+    [subscribe, buildFilters]
+  );
+
+  const refreshFeed = useCallback(() => {
+    feedSubscription?.unsubscribe();
+    setPendingEvents([]);
+    setRefreshing(true);
+    loadingInitialRef.current = true;
+    const handle = fetchInitial(true);
+    setFeedSubscription(handle);
+  }, [feedSubscription, fetchInitial]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || events.length === 0) return;
+    setLoadingMore(true);
+    const handle = subscribe(
+      buildFilters("older"),
+      {
+        onEose: () => setLoadingMore(false),
+      }
+    );
+    setFeedSubscription(handle);
+  }, [events.length, loadingMore, subscribe, buildFilters]);
+
+  const showNewEvents = useCallback(() => {
+    setEvents((prev) => mergeEvents(prev, pendingEvents));
+    setPendingEvents([]);
+  }, [pendingEvents]);
+
+  useEffect(() => {
+    registerRefresh(refreshFeed);
+  }, [registerRefresh, refreshFeed]);
+
+  useEffect(() => {
+    feedSubscription?.unsubscribe();
+    setEvents([]);
+    setPendingEvents([]);
+    setLoadingInitial(true);
+    oldestNoteTimestampRef.current = null;
+    oldestPollTimestampRef.current = null;
+    const handle = fetchInitial();
+    setFeedSubscription(handle);
+
+    return () => handle.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventSource]);
+
+  const pollForNew = useCallback(() => {
+    return subscribe(buildFilters("newer"));
+  }, [subscribe, buildFilters]);
+
+  useEffect(() => {
+    const handleRef = { current: null as SubscriptionHandle | null };
+    const interval = setInterval(() => {
+      handleRef.current?.unsubscribe();
+      handleRef.current = pollForNew();
+    }, 60_000);
+
+    return () => {
+      clearInterval(interval);
+      handleRef.current?.unsubscribe();
+    };
+  }, [pollForNew]);
+
+  const visibleEvents = useMemo(() => events, [events]);
+
+  useEffect(() => {
+    if (events.length === 0) {
+      oldestNoteTimestampRef.current = null;
+      oldestPollTimestampRef.current = null;
+      return;
+    }
+
+    const oldestNote = events
+      .filter((event) => event.kind === KIND_NOTE)
+      .reduce<number | null>((oldest, event) => {
+        return oldest == null || event.created_at < oldest ? event.created_at : oldest;
+      }, null);
+    const oldestPoll = events
+      .filter((event) => event.kind === KIND_POLL)
+      .reduce<number | null>((oldest, event) => {
+        return oldest == null || event.created_at < oldest ? event.created_at : oldest;
+      }, null);
+
+    oldestNoteTimestampRef.current = oldestNote;
+    oldestPollTimestampRef.current = oldestPoll;
+  }, [events]);
+
+  useEffect(() => {
+    if (visibleEvents.length === 0) return;
+    requestReportCheck(visibleEvents.map((event) => event.id));
+    requestUserReportCheck(visibleEvents.map((event) => event.pubkey));
+  }, [visibleEvents, requestReportCheck, requestUserReportCheck]);
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <UnifiedFeed
+          data={visibleEvents}
+          loading={loadingInitial}
+          loadingMore={loadingMore}
+          refreshing={refreshing}
+          onEndReached={loadMore}
+          onRefresh={refreshFeed}
+          newItemCount={pendingEvents.length}
+          onShowNewItems={showNewEvents}
+          newItemLabel="posts"
+          computeItemKey={(_, event) => event.id}
+          itemContent={(_, event) => <MixedFeedItem event={event} />}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default MixedFeed;

--- a/src/components/Login/LoginModal.tsx
+++ b/src/components/Login/LoginModal.tsx
@@ -54,8 +54,17 @@ export const LoginModal: React.FC<Props> = ({ open, onClose }) => {
 
   useEffect(() => {
     const initialize = async () => {
-      const result = await NostrSignerPlugin.getInstalledSignerApps();
-      setInstalledSigners(result.apps);
+      if (!isAndroidNative()) {
+        setInstalledSigners([]);
+        return;
+      }
+      try {
+        const result = await NostrSignerPlugin.getInstalledSignerApps();
+        setInstalledSigners(result.apps);
+      } catch (err) {
+        console.error("Failed to load installed Android signers", err);
+        setInstalledSigners([]);
+      }
     };
     initialize();
   }, []);

--- a/src/components/SidePane/index.tsx
+++ b/src/components/SidePane/index.tsx
@@ -15,6 +15,7 @@ import TagIcon from "@mui/icons-material/Tag";
 import ArticleIcon from "@mui/icons-material/Article";
 import MovieIcon from "@mui/icons-material/Movie";
 import PeopleIcon from "@mui/icons-material/People";
+import DashboardIcon from "@mui/icons-material/Dashboard";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { SvgIconComponent } from "@mui/icons-material";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -24,6 +25,11 @@ import { useSubNav } from "../../contexts/SubNavContext";
 // feed is currently mounted. Active state is read from localStorage so we can
 // show the correct selection even for feeds that aren't mounted yet.
 const MOBILE_SUB_ITEMS: Record<string, { key: string; label: string }[]> = {
+  all: [
+    { key: "global", label: "Global" },
+    { key: "following", label: "Following" },
+    { key: "webOfTrust", label: "Web of Trust" },
+  ],
   polls: [
     { key: "global", label: "Global" },
     { key: "following", label: "Following" },
@@ -47,6 +53,7 @@ const MOBILE_SUB_ITEMS: Record<string, { key: string; label: string }[]> = {
 };
 
 const FEED_STORAGE_KEYS: Record<string, string> = {
+  all: "pollerama:mixedSource",
   polls: "pollerama:pollSource",
   notes: "pollerama:lastNotesTab",
   topics: "pollerama:lastTopicsTab",
@@ -54,6 +61,7 @@ const FEED_STORAGE_KEYS: Record<string, string> = {
 };
 
 const FEED_DEFAULT_SUB: Record<string, string> = {
+  all: "global",
   polls: "global",
   notes: "discover",
   topics: "interests",
@@ -61,6 +69,7 @@ const FEED_DEFAULT_SUB: Record<string, string> = {
 };
 
 const feedOptions: { value: string; label: string; Icon: SvgIconComponent }[] = [
+  { value: "all",          label: "All",          Icon: DashboardIcon },
   { value: "polls",        label: "Polls",        Icon: HowToVoteIcon },
   { value: "topics",       label: "Topics",       Icon: TagIcon },
   { value: "notes",        label: "Notes",        Icon: ArticleIcon },


### PR DESCRIPTION
## Summary

@abh3po This PR starts work on issue #44 by exposing a new mixed feed that combines regular Nostr notes (`kind:1`) and polls (`kind:1068`) in one visible timeline. The mixed feed is intended as the first PR in a larger breakdown of issue #44

It also fixes a web-only login crash caused by calling the Android-only signer plugin on `localhost` / web.

## Changes

- added a new `All` feed route at `/feeds/all`
- added a new `All` sidebar tab without removing the existing `Polls` or `Notes` feeds
- implemented a mixed feed that fetches notes and polls separately, then merges them by `created_at`
- preserved source filters for the mixed feed:
  - `Global`
  - `Following`
  - `Web of Trust`
- fixed `LoginModal` so Android-only signer discovery does not run on web

<img width="1897" height="870" alt="Screenshot 2026-04-12 165643" src="https://github.com/user-attachments/assets/4a0c4570-9646-49dd-8fe0-1ace7c8de476" />

<img width="1893" height="841" alt="Screenshot 2026-04-12 193845" src="https://github.com/user-attachments/assets/da35a14e-c736-424a-8f0a-9c248af2a0e3" />


