### PR TITLE
fix the scrollbar placement

### DIFF
--- a/src/components/Feed/FeedsLayout.tsx
+++ b/src/components/Feed/FeedsLayout.tsx
@@ -8,10 +8,8 @@ const FeedsLayout: React.FC = () => {
   return (
     <FeedActionsProvider>
       <Box
-        maxWidth={800}
-        mx="auto"
-        px={{ xs: 0, sm: 2 }}
         sx={{
+          width: "100%",
           height: "100%",
           display: "flex",
           flexDirection: "column",

--- a/src/components/SidePane/index.tsx
+++ b/src/components/SidePane/index.tsx
@@ -147,6 +147,8 @@ const NavSidebar: React.FC<NavSidebarProps> = ({ open, onToggle }) => {
             py: 1,
             overflowX: "hidden",
             overflowY: "auto",
+            scrollbarWidth: "none",
+            "&::-webkit-scrollbar": { display: "none" },
             transition: "width 0.2s ease",
           }}
         >
@@ -246,6 +248,8 @@ const NavSidebar: React.FC<NavSidebarProps> = ({ open, onToggle }) => {
           py: 1,
           overflowX: "hidden",
           overflowY: "auto",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
           transition: "width 0.2s ease",
         }}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,39 @@ html, body {
   overflow: hidden;
 }
 
+html {
+  scrollbar-color: rgba(164, 172, 184, 0.82) rgba(10, 18, 28, 0.22);
+}
+
+* {
+  scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar {
+  width: 14px;
+  height: 14px;
+}
+
+*::-webkit-scrollbar-track {
+  background: rgba(10, 18, 28, 0.22);
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(178, 186, 198, 0.92), rgba(136, 145, 158, 0.92));
+  border: 2px solid rgba(10, 18, 28, 0.22);
+  border-radius: 999px;
+  min-height: 44px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, rgba(194, 201, 212, 0.96), rgba(150, 159, 171, 0.96));
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 #root {
   height: 100%;
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -8,12 +8,12 @@ html {
 }
 
 * {
-  scrollbar-width: thin;
+  scrollbar-width: auto;
 }
 
 *::-webkit-scrollbar {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
 }
 
 *::-webkit-scrollbar-track {
@@ -25,7 +25,7 @@ html {
   background: linear-gradient(180deg, rgba(178, 186, 198, 0.92), rgba(136, 145, 158, 0.92));
   border: 2px solid rgba(10, 18, 28, 0.22);
   border-radius: 999px;
-  min-height: 44px;
+  min-height: 60px;
 }
 
 *::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
### Summary

@abh3po This PR improves scrollbar placement and styling for the app layout.

### Changes

- moved the visible feed scrollbar to the far right edge by making the feed shell full width
- hid internal sidebar scrollbars
- added global dark-friendly scrollbar styling, a neutral tone that works across all themes

### Result

The scrollbar now looks cleaner, feels more intentional, and no longer clashes with the app's different color themes.
Before:
<img width="1911" height="643" alt="Screenshot 2026-04-13 021800" src="https://github.com/user-attachments/assets/4baaa570-17cb-48d2-9ef0-885d1588b611" />

After:
<img width="1901" height="638" alt="Screenshot 2026-04-13 022420" src="https://github.com/user-attachments/assets/1fccfe26-a481-463a-b12a-e100c0b241b7" />

