### PR TITLE
add clickable profile-name

### DIFF
--- a/src/components/Common/Comments/CommentSection.tsx
+++ b/src/components/Common/Comments/CommentSection.tsx
@@ -42,6 +42,8 @@ import { ReportDialog } from "../../Report/ReportDialog";
 import { ReportReason } from "../../../contexts/reports-context";
 import { getAppBaseUrl } from "../../../utils/platform";
 import { Profile } from "../../../nostr/types";
+import { useNavigate } from "react-router-dom";
+import { openProfileTab } from "../../../nostr";
 
 function dedup(arr: string[]): string[] {
   const seen = new Set<string>();
@@ -91,6 +93,7 @@ const CommentCard: React.FC<CommentCardProps> = ({ comment, depth, commentAncest
   const { user } = useUserContext();
   const eventRelays = useEventRelays(comment.id);
   const { reportEvent, reportUser } = useReports();
+  const navigate = useNavigate();
 
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const [relayModalOpen, setRelayModalOpen] = useState(false);
@@ -116,13 +119,52 @@ const CommentCard: React.FC<CommentCardProps> = ({ comment, depth, commentAncest
   const authorName =
     commentUser?.name ||
     (() => { const n = nip19.npubEncode(comment.pubkey); return n.slice(0, 10) + "..."; })();
+  const authorNpub = nip19.npubEncode(comment.pubkey);
 
   return (
     <>
       <Card variant="outlined" style={{ marginTop: "8px" }}>
         <CardHeader
-          avatar={<Avatar src={commentUser?.picture || DEFAULT_IMAGE_URL} />}
-          title={authorName}
+          avatar={
+            <Avatar
+              src={commentUser?.picture || DEFAULT_IMAGE_URL}
+              onClick={() => openProfileTab(authorNpub, navigate)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openProfileTab(authorNpub, navigate);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              sx={{ cursor: "pointer" }}
+            />
+          }
+          title={
+            <Box
+              onClick={() => openProfileTab(authorNpub, navigate)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openProfileTab(authorNpub, navigate);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              sx={{
+                display: "inline-flex",
+                maxWidth: "100%",
+                cursor: "pointer",
+                "&:hover .profile-name, &:focus-visible .profile-name": {
+                  textDecoration: "underline",
+                },
+              }}
+            >
+              <Typography className="profile-name" noWrap>
+                {authorName}
+              </Typography>
+            </Box>
+          }
           subheader={calculateTimeAgo(comment.created_at)}
           action={
             <IconButton size="small" onClick={(e) => setMenuAnchor(e.currentTarget)}>

--- a/src/components/Feed/NotesFeed/components/RepostedNoteCard.tsx
+++ b/src/components/Feed/NotesFeed/components/RepostedNoteCard.tsx
@@ -5,6 +5,8 @@ import { useAppContext } from "../../../../hooks/useAppContext";
 import { Event } from "nostr-tools";
 import { Notes } from "../../../../components/Notes";
 import ReplayIcon from '@mui/icons-material/Replay';
+import { useNavigate } from "react-router-dom";
+import { openProfileTab } from "../../../../nostr";
 
 interface RepostsCardProps {
   note: Event;
@@ -13,6 +15,7 @@ interface RepostsCardProps {
 
 const RepostsCard: React.FC<RepostsCardProps> = ({ note, reposts }) => {
   const { profiles, fetchUserProfileThrottled } = useAppContext();
+  const navigate = useNavigate();
 
   // Filter reposts that belong to this note by checking tags for 'e' with note.id
   const matchingReposts = reposts.filter((r) => {
@@ -48,11 +51,38 @@ const RepostsCard: React.FC<RepostsCardProps> = ({ note, reposts }) => {
 
             return (
               <Tooltip title={`Reposted by ${displayName}`} key={r.id}>
-                <Avatar
-                  src={profile?.picture || DEFAULT_IMAGE_URL}
-                  alt={displayName}
-                  sx={{ width: 24, height: 24 }}
-                />
+                <div
+                  onClick={() => openProfileTab(nip19.npubEncode(r.pubkey), navigate)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openProfileTab(nip19.npubEncode(r.pubkey), navigate);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    cursor: "pointer",
+                  }}
+                >
+                  <Avatar
+                    src={profile?.picture || DEFAULT_IMAGE_URL}
+                    alt={displayName}
+                    sx={{ width: 24, height: 24 }}
+                  />
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: "inherit",
+                      "&:hover, &:focus-visible": { textDecoration: "underline" },
+                    }}
+                  >
+                    {displayName}
+                  </Typography>
+                </div>
               </Tooltip>
             );
           })}

--- a/src/components/FollowPacks/FollowPackMembersDialog.tsx
+++ b/src/components/FollowPacks/FollowPackMembersDialog.tsx
@@ -80,11 +80,23 @@ export const FollowPackMembersDialog: React.FC<FollowPackMembersDialogProps> = (
                   py: 0.75,
                   cursor: "pointer",
                   "&:hover": { bgcolor: "action.hover" },
+                  "&:hover .profile-name, &:focus-visible .profile-name": {
+                    textDecoration: "underline",
+                  },
                 }}
                 onClick={() => {
                   onClose();
                   openProfileTab(npub, navigate);
                 }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onClose();
+                    openProfileTab(npub, navigate);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
                 secondaryAction={
                   user && user.pubkey !== pk && !user.follows?.includes(pk) ? (
                     <Button size="small" variant="outlined" sx={{ minWidth: 70 }}>
@@ -101,7 +113,7 @@ export const FollowPackMembersDialog: React.FC<FollowPackMembersDialogProps> = (
                 </ListItemAvatar>
                 <ListItemText
                   primary={
-                    <Typography variant="body2" fontWeight={500} noWrap>
+                    <Typography className="profile-name" variant="body2" fontWeight={500} noWrap>
                       {name}
                     </Typography>
                   }

--- a/src/components/Notes/index.tsx
+++ b/src/components/Notes/index.tsx
@@ -411,8 +411,23 @@ export const Notes: React.FC<NotesProps> = ({
               />
             }
             title={
-              <Box sx={{ minWidth: 0 }}>
-                <Typography>
+              <Box
+                onClick={() => openProfileTab(nip19.npubEncode(event.pubkey), navigate)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    openProfileTab(nip19.npubEncode(event.pubkey), navigate);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+                sx={{
+                  minWidth: 0,
+                  cursor: "pointer",
+                  "&:hover .profile-name": { textDecoration: "underline" },
+                }}
+              >
+                <Typography className="profile-name">
                   {profiles?.get(event.pubkey)?.name ||
                     profiles?.get(event.pubkey)?.username ||
                     profiles?.get(event.pubkey)?.nip05 ||

--- a/src/components/Notifications/NotificationsPage.tsx
+++ b/src/components/Notifications/NotificationsPage.tsx
@@ -163,6 +163,41 @@ const NotificationsPage: React.FC = () => {
     }
   };
 
+  const getNotifActionText = (ev: Event): string | null => {
+    const parsed = parseNotification(ev);
+    if (!parsed.fromPubkey) return null;
+
+    switch (parsed.type) {
+      case "poll-response":
+        return "responded to your poll";
+      case "comment":
+        return ev.kind === 1068
+          ? "mentioned you in a poll"
+          : ev.kind === 30023
+            ? "mentioned you in an article"
+            : "commented";
+      case "reaction":
+        return `reacted ${parsed.reaction}`;
+      case "zap":
+        return "zapped you ⚡";
+      case "repost":
+        return "reposted you";
+      case "highlight":
+        return "highlighted your post";
+      default:
+        return null;
+    }
+  };
+
+  const handleProfileClick = (
+    e: React.MouseEvent | React.KeyboardEvent,
+    pubkey: string | null
+  ) => {
+    if (!pubkey) return;
+    e.stopPropagation();
+    navigate(`/profile/${nip19.npubEncode(pubkey)}`);
+  };
+
   const handleItemClick = (ev: Event) => {
     const parsed = parseNotification(ev);
 
@@ -237,15 +272,54 @@ const NotificationsPage: React.FC = () => {
                 <React.Fragment key={ev.id}>
                   <ListItem
                     alignItems="flex-start"
-                    onClick={() => handleItemClick(ev)}
-                    sx={{ cursor: "pointer", "&:hover": { bgcolor: "action.hover" } }}
+                      onClick={() => handleItemClick(ev)}
+                      sx={{ cursor: "pointer", "&:hover": { bgcolor: "action.hover" } }}
                   >
                     <ListItemAvatar>
-                      <Avatar src={getAvatar(parsed.fromPubkey)} />
+                      <Avatar
+                        src={getAvatar(parsed.fromPubkey)}
+                        onClick={(e) => handleProfileClick(e, parsed.fromPubkey)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleProfileClick(e, parsed.fromPubkey);
+                          }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        sx={{ cursor: parsed.fromPubkey ? "pointer" : "default" }}
+                      />
                     </ListItemAvatar>
                     <ListItemText
                       primary={
-                        <Typography variant="subtitle2">{title}</Typography>
+                        getNotifActionText(ev) && parsed.fromPubkey ? (
+                          <Typography variant="subtitle2">
+                            <Box
+                              component="span"
+                              onClick={(e) => handleProfileClick(e, parsed.fromPubkey)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  handleProfileClick(e, parsed.fromPubkey);
+                                }
+                              }}
+                              role="button"
+                              tabIndex={0}
+                              sx={{
+                                cursor: "pointer",
+                                fontWeight: 600,
+                                "&:hover, &:focus-visible": {
+                                  textDecoration: "underline",
+                                },
+                              }}
+                            >
+                              {getName(parsed.fromPubkey)}
+                            </Box>{" "}
+                            {getNotifActionText(ev)}
+                          </Typography>
+                        ) : (
+                          <Typography variant="subtitle2">{title}</Typography>
+                        )
                       }
                       secondary={
                         <>

--- a/src/components/PollResponse/PollResponseForm.tsx
+++ b/src/components/PollResponse/PollResponseForm.tsx
@@ -381,8 +381,23 @@ const PollResponseForm: React.FC<PollResponseFormProps> = ({
                 />
               }
               title={
-                <Box sx={{ minWidth: 0 }}>
-                  <Typography>
+                <Box
+                  onClick={() => openProfileTab(nip19.npubEncode(pollEvent.pubkey), navigate)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      openProfileTab(nip19.npubEncode(pollEvent.pubkey), navigate);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  sx={{
+                    minWidth: 0,
+                    cursor: "pointer",
+                    "&:hover .profile-name": { textDecoration: "underline" },
+                  }}
+                >
+                  <Typography className="profile-name">
                     {profiles?.get(pollEvent.pubkey)?.name ||
                       profiles?.get(pollEvent.pubkey)?.username ||
                       profiles?.get(pollEvent.pubkey)?.nip05 ||

--- a/src/components/Ratings/ReviewCard.tsx
+++ b/src/components/Ratings/ReviewCard.tsx
@@ -10,14 +10,15 @@ import {
   Link,
 } from "@mui/material";
 import { nip19, Event } from "nostr-tools";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import { useAppContext } from "../../hooks/useAppContext";
 import { useMetadata } from "../../hooks/MetadataProvider";
 import { selectBestMetadataEvent } from "../../utils/utils";
 import { useUserContext } from "../../hooks/useUserContext";
 import { nostrRuntime } from "../../singletons";
 import { useRelays } from "../../hooks/useRelays";
-import { Link as RouterLink } from "react-router-dom";
 import { Nip05Badge } from "../Common/Nip05Badge";
+import { openProfileTab } from "../../nostr";
 
 interface Props {
   event: Event;
@@ -41,25 +42,26 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
   const { user } = useUserContext();
   const { registerEntity, metadata } = useMetadata();
   const { relays } = useRelays();
+  const navigate = useNavigate();
 
   const [entityDisplay, setEntityDisplay] = useState<EntityDisplay | null>(null);
 
   const reviewUser = profiles?.get(pubkey);
   if (!reviewUser) fetchUserProfileThrottled(pubkey);
 
-  const displayName = reviewUser?.name || nip19.npubEncode(pubkey).slice(0, 12) + "...";
+  const displayName =
+    reviewUser?.name || nip19.npubEncode(pubkey).slice(0, 12) + "...";
   const picture = reviewUser?.picture;
+  const profileNpub = nip19.npubEncode(pubkey);
 
   useEffect(() => {
     const fetchEntityMetadata = async () => {
-      // Check for 'd' tag (identifier like "movie:tt1234567" or "profile:pubkey")
       const dTag = event.tags.find((t) => t[0] === "d")?.[1];
 
       if (dTag?.startsWith("movie:")) {
         const imdbId = dTag.replace("movie:", "");
         registerEntity("movie", imdbId);
 
-        // Wait a bit for metadata to load
         setTimeout(() => {
           const movieMetadata = metadata.get(imdbId);
           const activeEvent = movieMetadata
@@ -96,7 +98,6 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
         return;
       }
 
-      // Check for 'e' tag (event reference - could be poll or note)
       const eTagEntry = event.tags.find((t) => t[0] === "e");
       const eTag = eTagEntry?.[1];
       if (eTag) {
@@ -108,7 +109,6 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
           const eventData = await nostrRuntime.fetchBatched(fetchRelays, eTag);
           if (eventData) {
             if (eventData.kind === 1068) {
-              // Poll
               const question = eventData.tags.find((t) => t[0] === "question")?.[1];
               setEntityDisplay({
                 type: "poll",
@@ -117,8 +117,9 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
                 link: `/respond/${nip19.neventEncode({ id: eTag, relays: [] })}`,
               });
             } else if (eventData.kind === 1) {
-              // Note
-              const noteContent = eventData.content.slice(0, 100) + (eventData.content.length > 100 ? "..." : "");
+              const noteContent =
+                eventData.content.slice(0, 100) +
+                (eventData.content.length > 100 ? "..." : "");
               setEntityDisplay({
                 type: "note",
                 title: noteContent || "Note",
@@ -133,7 +134,6 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
         return;
       }
 
-      // Fallback for unknown entity types
       setEntityDisplay({
         type: "unknown",
         title: dTag || "Unknown entity",
@@ -141,26 +141,53 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
     };
 
     fetchEntityMetadata();
-  }, [event, metadata, profiles, user?.follows, registerEntity, fetchUserProfileThrottled, relays]);
+  }, [
+    event,
+    metadata,
+    profiles,
+    user?.follows,
+    registerEntity,
+    fetchUserProfileThrottled,
+    relays,
+  ]);
 
   return (
     <Card sx={{ mb: 2 }}>
       <CardContent>
         <Stack direction="row" spacing={2} alignItems="flex-start" mb={2}>
-          <Avatar
-            src={picture}
-            alt={displayName}
-            sx={{ width: 40, height: 40 }}
-          />
-          <Box sx={{ flex: 1 }}>
-            <Typography variant="subtitle1" fontWeight={600}>
-              {displayName}
-            </Typography>
-            <Nip05Badge nip05={reviewUser?.nip05} pubkey={pubkey} />
-            <Typography variant="body2" color="text.secondary">
-              {rating.toFixed(1)} ★
-            </Typography>
+          <Box
+            onClick={() => openProfileTab(profileNpub, navigate)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openProfileTab(profileNpub, navigate);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            sx={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 2,
+              flex: 1,
+              minWidth: 0,
+              cursor: "pointer",
+              "&:hover .profile-name, &:focus-visible .profile-name": {
+                textDecoration: "underline",
+              },
+            }}
+          >
+            <Avatar src={picture} alt={displayName} sx={{ width: 40, height: 40 }} />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography className="profile-name" variant="subtitle1" fontWeight={600} noWrap>
+                {displayName}
+              </Typography>
+              <Nip05Badge nip05={reviewUser?.nip05} pubkey={pubkey} />
+            </Box>
           </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
+            {rating.toFixed(1)} ★
+          </Typography>
         </Stack>
 
         {entityDisplay && (
@@ -183,7 +210,11 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
               />
             )}
             <Box sx={{ flex: 1 }}>
-              <Typography variant="caption" color="text.secondary" sx={{ textTransform: "uppercase" }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ textTransform: "uppercase" }}
+              >
                 Rated {entityDisplay.type}
               </Typography>
               {entityDisplay.link ? (
@@ -211,11 +242,7 @@ const ReviewCard: React.FC<Props> = ({ event }) => {
           </Box>
         )}
 
-        {content && (
-          <Typography variant="body1">
-            {content}
-          </Typography>
-        )}
+        {content && <Typography variant="body1">{content}</Typography>}
       </CardContent>
     </Card>
   );

--- a/src/components/Search/SearchModal.tsx
+++ b/src/components/Search/SearchModal.tsx
@@ -130,6 +130,15 @@ function AuthorChip({
         e.stopPropagation();
         onNavigate(`/profile/${npub}`);
       }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          onNavigate(`/profile/${npub}`);
+        }
+      }}
+      role="button"
+      tabIndex={0}
       sx={{
         display: "inline-flex",
         alignItems: "center",
@@ -138,7 +147,9 @@ function AuthorChip({
         cursor: "pointer",
         maxWidth: "100%",
         overflow: "hidden",
-        "&:hover .author-name": { textDecoration: "underline" },
+        "&:hover .author-name, &:focus-visible .author-name": {
+          textDecoration: "underline",
+        },
       }}
     >
       <Avatar
@@ -448,15 +459,20 @@ export function SearchModal({ open, onClose }: Props) {
                       {visibleProfiles.map((event) => {
                         const p = parseProfile(event);
                         return (
-                          <ListItemButton
-                            key={event.id}
-                            onClick={() =>
-                              goTo(
-                                `/profile/${nip19.npubEncode(event.pubkey)}`
-                              )
-                            }
-                            sx={{ minWidth: 0 }}
-                          >
+                            <ListItemButton
+                              key={event.id}
+                              onClick={() =>
+                                goTo(
+                                  `/profile/${nip19.npubEncode(event.pubkey)}`
+                                )
+                              }
+                              sx={{
+                                minWidth: 0,
+                                "&:hover .profile-name, &:focus-visible .profile-name": {
+                                  textDecoration: "underline",
+                                },
+                              }}
+                            >
                             <ListItemAvatar sx={{ minWidth: 48 }}>
                               <Avatar
                                 src={p.picture}
@@ -471,6 +487,7 @@ export function SearchModal({ open, onClose }: Props) {
                               primaryTypographyProps={{
                                 variant: "body2",
                                 noWrap: true,
+                                className: "profile-name",
                               }}
                               secondaryTypographyProps={{
                                 variant: "caption",


### PR DESCRIPTION
Currently we can't click on the post author's name to navigate to profile only clicking on picture works 
@abh3po this adds that 

<img width="977" height="560" alt="Screenshot 2026-04-13 035105" src="https://github.com/user-attachments/assets/de4b0f47-de01-48e3-90b4-978e5488ba56" />
