### PR TITLE
fix: publish user-authored events via writeRelays instead of read relays

### DIFF
--- a/src/components/Common/Likes/likes.tsx
+++ b/src/components/Common/Likes/likes.tsx
@@ -41,7 +41,7 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
   const { likesMap, fetchLikesThrottled, addEventToMap } = useAppContext();
   const { showNotification } = useNotification();
   const { user } = useUserContext();
-  const { relays } = useRelays();
+  const { relays, writeRelays } = useRelays();
   const [showPicker, setShowPicker] = useState(false);
   const theme = useTheme();
 
@@ -64,7 +64,7 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
     };
 
     const finalEvent = await signEvent(event, user.privateKey);
-    pool.publish(relays, finalEvent!);
+    pool.publish(writeRelays, finalEvent!);
     addEventToMap(finalEvent!);
     setShowPicker(false);
   };

--- a/src/components/Common/Repost/reposts.tsx
+++ b/src/components/Common/Repost/reposts.tsx
@@ -24,7 +24,7 @@ interface RepostButtonProps {
 const RepostButton: React.FC<RepostButtonProps> = ({ event }) => {
   const { user } = useUserContext();
   const { showNotification } = useNotification();
-  const { relays } = useRelays();
+  const { relays, writeRelays } = useRelays();
   const { repostsMap, fetchRepostsThrottled, addEventToMap } = useAppContext();
 
   const [reposted, setReposted] = useState(false);
@@ -81,7 +81,7 @@ const RepostButton: React.FC<RepostButtonProps> = ({ event }) => {
 
     try {
       const signedEvent = await signEvent(repostTemplate, user!.privateKey);
-      pool.publish(relays, signedEvent);
+      pool.publish(writeRelays, signedEvent);
       addEventToMap(signedEvent);
       setReposted(true);
     } catch (error) {

--- a/src/components/Notes/index.tsx
+++ b/src/components/Notes/index.tsx
@@ -183,7 +183,7 @@ export const Notes: React.FC<NotesProps> = ({
     };
 
     const signed = await signEvent(newEvent);
-    pool.publish(relays, signed);
+    pool.publish(writeRelays, signed);
     setUser({
       pubkey: signed.pubkey,
       ...user,

--- a/src/contexts/reports-context.tsx
+++ b/src/contexts/reports-context.tsx
@@ -52,7 +52,7 @@ export const ReportsContext = createContext<ReportsContextInterface | null>(
 
 export function ReportsProvider({ children }: { children: ReactNode }) {
   const { user } = useUserContext();
-  const { relays } = useRelays();
+  const { relays, writeRelays } = useRelays();
 
   // IDs (event ids or pubkeys) the current user has reported
   const [myReportedIds, setMyReportedIds] = useState<Set<string>>(new Set());
@@ -246,11 +246,11 @@ export function ReportsProvider({ children }: { children: ReactNode }) {
         content,
       };
       const signed = await signEvent(eventTemplate);
-      pool.publish(relays, signed);
+      pool.publish(writeRelays, signed);
       // Optimistic: mark as reported immediately
       setMyReportedIds((prev) => new Set(Array.from(prev).concat([eventId, eventPubkey])));
     },
-    [relays]
+    [writeRelays]
   );
 
   const reportUser = useCallback(
@@ -262,10 +262,10 @@ export function ReportsProvider({ children }: { children: ReactNode }) {
         content,
       };
       const signed = await signEvent(eventTemplate);
-      pool.publish(relays, signed);
+      pool.publish(writeRelays, signed);
       setMyReportedIds((prev) => new Set(Array.from(prev).concat([pubkey])));
     },
-    [relays]
+    [writeRelays]
   );
 
   return (


### PR DESCRIPTION
This PR standardizes outbound publishing for user-authored actions to use `writeRelays` (NIP-65 outbox relays) instead of `relays` (read/subscription relays).

### Why
check issue #184 

### Changes
- Updated likes publish path to use `writeRelays`
- Updated repost publish path to use `writeRelays`
- Updated reports publish path to use `writeRelays`
- Updated follow/contact-list update publish path in Notes to use `writeRelays`
- Updated related hook dependencies where needed (`reports-context`) to match new relay source

### Impact
Improves compatibility with NIP-65 split relay setups and reduces avoidable publish failures.