### PR TITLE
Add https deep linking for pollerama.fun

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,12 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="nostr-polls" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="pollerama.fun" />
+            </intent-filter>
         </activity>
 
         <provider


### PR DESCRIPTION
Fixes #183

Adds an https intent filter for pollerama.fun in AndroidManifest.xml so tapping a shared poll link on Android opens the app instead of the browser.

The appUrlOpen handler already exists in useAndroidNotifications.ts, just needed the manifest entry to trigger it for https URLs.

Note: verified app links also need assetlinks.json hosted at pollerama.fun/.well-known/assetlinks.json, that's a server-side change.

Before:


https://github.com/user-attachments/assets/690c0e9a-0ff2-4c05-8538-125b467a0c2b




After:



https://github.com/user-attachments/assets/1e824eec-ccc0-4cd3-a289-698eeb475eb9








