### PR TITLE
feat: native app links and Pollerama integration bridge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Outlet,
   Navigate,
   useParams,
+  useNavigate,
 } from "react-router-dom";
 
 import { StatusBar, Style } from "@capacitor/status-bar";
@@ -99,8 +100,42 @@ function DynamicThemeWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
+function useDeepLinks() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let listener: Awaited<ReturnType<typeof CapApp.addListener>> | null = null;
+    CapApp.addListener("appUrlOpen", (event) => {
+      const url = event.url;
+      try {
+        const u = new URL(url);
+        let path = "";
+        
+        if (u.hostname === "pollerama.fun") {
+          path = u.pathname;
+        } else if (url.startsWith("nostr-polls://")) {
+           path = url.replace("nostr-polls://", "/").replace(/\/\/*/g, "/");
+        }
+
+        if (path) {
+          navigate(path);
+        }
+      } catch (err) {
+        console.error("Failed to parse deep link", err);
+      }
+    }).then((l) => {
+      listener = l;
+    });
+
+    return () => {
+      listener?.remove();
+    };
+  }, [navigate]);
+}
+
 // Inner component: static layout — header on top, sidebar + content below
 function AppContent() {
+  useDeepLinks();
   const [sidebarOpen, setSidebarOpen] = React.useState(
     () => localStorage.getItem("pollerama:sidebarOpen") !== "false"
   );

--- a/src/components/Common/Parsers/TextWithImages.tsx
+++ b/src/components/Common/Parsers/TextWithImages.tsx
@@ -312,6 +312,25 @@ const NostrParser = ({
       );
     }
 
+    if (type === "naddr" && data.kind === 30023) {
+      return (
+        <React.Fragment key={index}>
+          <Box sx={{ my: 1 }}>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={() => {
+                window.location.href = `https://pages.formstr.app/doc/${encoded}`;
+              }}
+            >
+              Open in Pages
+            </Button>
+          </Box>
+          {suffix}
+        </React.Fragment>
+      );
+    }
+
     if (type === "nprofile" || type === "npub") {
       const pubkey = type === "nprofile" ? data.pubkey : data;
       if (!profiles?.has(pubkey)) {


### PR DESCRIPTION
## Overview
@abh3po This PR establishes a seamless, native two-way app bridge between Pollerama and Formstr Pages, bypassing standard Chrome fallbacks to keep users inside our native ecosystem.
Closes issue #178 
## Changes
- **Android Intent Filters:** Upgraded `AndroidManifest.xml` to universally capture standard intents bypassing web fallbacks.
- **Capacitor Routing:** Built a `useDeepLinks` hook at the `AppLayout` level. Capacitor intercepts incoming standard and custom schema URLs from the OS, extracts the route payload, and injects it directly into React Router without losing app state.
- **Pages Detector UI:** Extended the `NostrParser` to natively recognize `naddr` references (Kind 30023 events). Instead of ignoring them, it injects a highly visible "Open in Pages" CTA button that invokes universal App Links (`https://pages.formstr.app/doc/...`) to jump natively into Formstr Pages.

https://github.com/user-attachments/assets/9f07cd41-17a3-4be3-9f4e-aeeb98632a71

