### PR TITLE
Complete issue #44 with full-client mixed feed reachability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import EventList from "./components/Feed/FeedsLayout";
 import NotesFeed from "./components/Feed/NotesFeed/components";
 import ProfilesFeed from "./components/Feed/ProfileFeed";
 import { PollFeed } from "./components/Feed/PollFeed";
+import MixedFeed from "./components/Feed/MixedFeed";
 import MoviesFeed from "./components/Feed/MoviesFeed";
 import FollowPacksFeed from "./components/Feed/FollowPacksFeed";
 import FollowPackDetail from "./components/FollowPacks/FollowPackDetail";
@@ -174,6 +175,7 @@ function AppContent() {
           <Route path="/ratings" element={<EventList />} />
 
           <Route path="/feeds" element={<FeedsLayout />}>
+            <Route path="all" element={<MixedFeed />} />
             <Route path="notes" element={<NotesFeed />} />
             <Route path="profiles" element={<ProfilesFeed />} />
             <Route path="topics" element={<TopicsFeed />}>

--- a/src/components/Feed/CreateFAB.tsx
+++ b/src/components/Feed/CreateFAB.tsx
@@ -13,11 +13,11 @@ const CreateFAB: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { isScrolledDown, scrollToTop, refresh } = useFeedActions();
-  const isAllFeed = location.pathname.startsWith("/feeds/all");
+  const isAllFeed = /\/feeds\/all(?:\/|$)/.test(location.pathname);
 
   const handleCreate = () => {
     setOpen(false);
-    if (location.pathname.startsWith("/feeds/polls")) {
+    if (/\/feeds\/polls(?:\/|$)/.test(location.pathname)) {
       navigate("/create?type=poll");
     } else {
       const match = location.pathname.match(/\/feeds\/topics\/(.+)/);
@@ -85,22 +85,23 @@ const CreateFAB: React.FC = () => {
         onClick={handleRefresh}
         sx={actionSx}
       />
-      {isAllFeed ? (
-        <>
-          <SpeedDialAction
-            icon={<EditNoteIcon />}
-            tooltipTitle="Create note"
-            onClick={handleCreateNote}
-            sx={actionSx}
-          />
-          <SpeedDialAction
-            icon={<PollIcon />}
-            tooltipTitle="Create poll"
-            onClick={handleCreatePoll}
-            sx={actionSx}
-          />
-        </>
-      ) : (
+      {isAllFeed && (
+        <SpeedDialAction
+          icon={<EditNoteIcon />}
+          tooltipTitle="Create note"
+          onClick={handleCreateNote}
+          sx={actionSx}
+        />
+      )}
+      {isAllFeed && (
+        <SpeedDialAction
+          icon={<PollIcon />}
+          tooltipTitle="Create poll"
+          onClick={handleCreatePoll}
+          sx={actionSx}
+        />
+      )}
+      {!isAllFeed && (
         <SpeedDialAction
           icon={<AddIcon />}
           tooltipTitle="Create"

--- a/src/components/Feed/CreateFAB.tsx
+++ b/src/components/Feed/CreateFAB.tsx
@@ -3,6 +3,8 @@ import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import EditNoteIcon from "@mui/icons-material/EditNote";
+import PollIcon from "@mui/icons-material/Poll";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useFeedActions } from "../../contexts/FeedActionsContext";
 
@@ -11,6 +13,7 @@ const CreateFAB: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { isScrolledDown, scrollToTop, refresh } = useFeedActions();
+  const isAllFeed = location.pathname.startsWith("/feeds/all");
 
   const handleCreate = () => {
     setOpen(false);
@@ -24,6 +27,16 @@ const CreateFAB: React.FC = () => {
         navigate("/create");
       }
     }
+  };
+
+  const handleCreateNote = () => {
+    setOpen(false);
+    navigate("/create");
+  };
+
+  const handleCreatePoll = () => {
+    setOpen(false);
+    navigate("/create?type=poll");
   };
 
   const handleScrollToTop = () => {
@@ -72,12 +85,29 @@ const CreateFAB: React.FC = () => {
         onClick={handleRefresh}
         sx={actionSx}
       />
-      <SpeedDialAction
-        icon={<AddIcon />}
-        tooltipTitle="Create"
-        onClick={handleCreate}
-        sx={actionSx}
-      />
+      {isAllFeed ? (
+        <>
+          <SpeedDialAction
+            icon={<EditNoteIcon />}
+            tooltipTitle="Create note"
+            onClick={handleCreateNote}
+            sx={actionSx}
+          />
+          <SpeedDialAction
+            icon={<PollIcon />}
+            tooltipTitle="Create poll"
+            onClick={handleCreatePoll}
+            sx={actionSx}
+          />
+        </>
+      ) : (
+        <SpeedDialAction
+          icon={<AddIcon />}
+          tooltipTitle="Create"
+          onClick={handleCreate}
+          sx={actionSx}
+        />
+      )}
     </SpeedDial>
   );
 };

--- a/src/components/Feed/MixedFeed.tsx
+++ b/src/components/Feed/MixedFeed.tsx
@@ -1,0 +1,331 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box } from "@mui/material";
+import { Event, Filter, verifyEvent } from "nostr-tools";
+import { useUserContext } from "../../hooks/useUserContext";
+import { useRelays } from "../../hooks/useRelays";
+import { useSubNav } from "../../contexts/SubNavContext";
+import { useFeedActions } from "../../contexts/FeedActionsContext";
+import { useReports } from "../../hooks/useReports";
+import { nostrRuntime } from "../../singletons";
+import { SubscriptionHandle } from "../../nostrRuntime/types";
+import { getRelaysForAuthors, prefetchOutboxRelays } from "../../nostr/OutboxService";
+import UnifiedFeed from "./UnifiedFeed";
+import PollResponseForm from "../PollResponse/PollResponseForm";
+import { Notes } from "../Notes";
+
+const KIND_NOTE = 1;
+const KIND_POLL = 1068;
+const MIXED_SOURCE_KEY = "pollerama:mixedSource";
+const INITIAL_BATCH_SIZE = 40;
+const PAGE_BATCH_SIZE = 20;
+
+type MixedSource = "global" | "following" | "webOfTrust";
+
+const isRootNote = (event: Event) => !event.tags.some((t) => t[0] === "e");
+
+const isDisplayable = (event: Event) =>
+  event.kind === KIND_POLL || (event.kind === KIND_NOTE && isRootNote(event));
+
+const mergeEvents = (existing: Event[], incoming: Event[]): Event[] => {
+  const map = new Map(existing.map((event) => [event.id, event]));
+  for (const event of incoming) {
+    map.set(event.id, event);
+  }
+  return Array.from(map.values()).sort((a, b) => b.created_at - a.created_at);
+};
+
+const MixedFeedItem = React.memo(({ event }: { event: Event }) => {
+  if (event.kind === KIND_POLL) {
+    return (
+      <Box sx={{ my: "20px", mx: { xs: 0, sm: "auto" }, width: "100%", maxWidth: { xs: "100%", sm: "600px" } }}>
+        <PollResponseForm pollEvent={event} />
+      </Box>
+    );
+  }
+
+  return <Notes event={event} />;
+});
+
+const MixedFeed: React.FC = () => {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [pendingEvents, setPendingEvents] = useState<Event[]>([]);
+  const [eventSource, setEventSource] = useState<MixedSource>(() => {
+    const saved = localStorage.getItem(MIXED_SOURCE_KEY);
+    return saved === "following" || saved === "webOfTrust" ? saved : "global";
+  });
+  const [feedSubscription, setFeedSubscription] = useState<SubscriptionHandle | undefined>();
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const loadingInitialRef = useRef(true);
+  const oldestNoteTimestampRef = useRef<number | null>(null);
+  const oldestPollTimestampRef = useRef<number | null>(null);
+
+  const { user } = useUserContext();
+  const { relays } = useRelays();
+  const { setItems, clearItems } = useSubNav();
+  const { registerRefresh } = useFeedActions();
+  const { requestReportCheck, requestUserReportCheck } = useReports();
+
+  useEffect(() => {
+    loadingInitialRef.current = loadingInitial;
+  }, [loadingInitial]);
+
+  useEffect(() => {
+    localStorage.setItem(MIXED_SOURCE_KEY, eventSource);
+    setItems([
+      {
+        key: "global",
+        label: "Global",
+        active: eventSource === "global",
+        onClick: () => setEventSource("global"),
+      },
+      {
+        key: "following",
+        label: "Following",
+        active: eventSource === "following",
+        onClick: () => setEventSource("following"),
+        disabled: !user || !user.follows?.length,
+      },
+      {
+        key: "webOfTrust",
+        label: "Web of Trust",
+        active: eventSource === "webOfTrust",
+        onClick: () => setEventSource("webOfTrust"),
+        disabled: !user || !user.webOfTrust || !user.webOfTrust.size,
+      },
+    ]);
+
+    return () => clearItems();
+  }, [eventSource, user, setItems, clearItems]);
+
+  const getSourceFilters = useCallback(
+    (filters: Filter[]) => {
+      const nextFilters: Filter[] = filters.map((filter) => ({ ...filter }));
+      let relayOverride: string[] | undefined;
+
+      if (eventSource === "following" && user?.follows?.length) {
+        const authors = user.follows;
+        nextFilters.forEach((filter) => {
+          filter.authors = authors;
+        });
+        prefetchOutboxRelays(authors);
+        relayOverride = getRelaysForAuthors(relays, authors);
+      }
+
+      if (eventSource === "webOfTrust" && user?.webOfTrust?.size) {
+        const authors = Array.from(user.webOfTrust);
+        nextFilters.forEach((filter) => {
+          filter.authors = authors;
+        });
+        prefetchOutboxRelays(authors);
+        relayOverride = getRelaysForAuthors(relays, authors);
+      }
+
+      return { filters: nextFilters, relayOverride };
+    },
+    [eventSource, user, relays]
+  );
+
+  const handleIncomingEvent = useCallback((event: Event) => {
+    if (!verifyEvent(event) || !isDisplayable(event)) return;
+    if (loadingInitialRef.current) {
+      setEvents((prev) => mergeEvents(prev, [event]));
+      return;
+    }
+    setPendingEvents((prev) => mergeEvents(prev, [event]));
+  }, []);
+
+  const subscribe = useCallback(
+    (
+      filters: Filter[],
+      options?: {
+        onEose?: () => void;
+        fresh?: boolean;
+      }
+    ) => {
+      const { filters: sourceFilters, relayOverride } = getSourceFilters(filters);
+      return nostrRuntime.subscribe(relayOverride ?? relays, sourceFilters, {
+        onEvent: handleIncomingEvent,
+        onEose: options?.onEose,
+        fresh: options?.fresh,
+      });
+    },
+    [getSourceFilters, relays, handleIncomingEvent]
+  );
+
+  const buildFilters = useCallback(
+    (kind: "initial" | "older" | "newer") => {
+      const now = Math.floor(Date.now() / 1000);
+      const noteFilter: Filter = {
+        kinds: [KIND_NOTE],
+        limit: kind === "initial" ? INITIAL_BATCH_SIZE : PAGE_BATCH_SIZE,
+      };
+      const pollFilter: Filter = {
+        kinds: [KIND_POLL],
+        limit: kind === "initial" ? INITIAL_BATCH_SIZE : PAGE_BATCH_SIZE,
+      };
+
+      if (kind === "initial") {
+        noteFilter.since = now - 86400;
+        pollFilter.since = now - 86400;
+      } else if (kind === "older") {
+        if (oldestNoteTimestampRef.current != null) {
+          noteFilter.until = oldestNoteTimestampRef.current;
+        }
+        if (oldestPollTimestampRef.current != null) {
+          pollFilter.until = oldestPollTimestampRef.current;
+        }
+      } else {
+        const newestNote = events
+          .filter((event) => event.kind === KIND_NOTE)
+          .reduce<number | null>((latest, event) => {
+            return latest == null || event.created_at > latest ? event.created_at : latest;
+          }, null);
+        const newestPoll = events
+          .filter((event) => event.kind === KIND_POLL)
+          .reduce<number | null>((latest, event) => {
+            return latest == null || event.created_at > latest ? event.created_at : latest;
+          }, null);
+
+        if (newestNote != null) {
+          noteFilter.since = newestNote + 1;
+        }
+        if (newestPoll != null) {
+          pollFilter.since = newestPoll + 1;
+        }
+      }
+
+      return [noteFilter, pollFilter];
+    },
+    [events]
+  );
+
+  const fetchInitial = useCallback(
+    (fresh?: boolean) => {
+      const handle = subscribe(buildFilters("initial"), {
+        fresh,
+        onEose: () => {
+          if (fresh) {
+            setRefreshing(false);
+            loadingInitialRef.current = false;
+          } else {
+            setLoadingInitial(false);
+          }
+        },
+      });
+      return handle;
+    },
+    [subscribe, buildFilters]
+  );
+
+  const refreshFeed = useCallback(() => {
+    feedSubscription?.unsubscribe();
+    setPendingEvents([]);
+    setRefreshing(true);
+    loadingInitialRef.current = true;
+    const handle = fetchInitial(true);
+    setFeedSubscription(handle);
+  }, [feedSubscription, fetchInitial]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || events.length === 0) return;
+    setLoadingMore(true);
+    const handle = subscribe(buildFilters("older"), {
+      onEose: () => setLoadingMore(false),
+    });
+    setFeedSubscription(handle);
+  }, [events.length, loadingMore, subscribe, buildFilters]);
+
+  const showNewEvents = useCallback(() => {
+    setEvents((prev) => mergeEvents(prev, pendingEvents));
+    setPendingEvents([]);
+  }, [pendingEvents]);
+
+  useEffect(() => {
+    registerRefresh(refreshFeed);
+  }, [registerRefresh, refreshFeed]);
+
+  useEffect(() => {
+    feedSubscription?.unsubscribe();
+    setEvents([]);
+    setPendingEvents([]);
+    setLoadingInitial(true);
+    oldestNoteTimestampRef.current = null;
+    oldestPollTimestampRef.current = null;
+    const handle = fetchInitial();
+    setFeedSubscription(handle);
+
+    return () => handle.unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventSource]);
+
+  const pollForNew = useCallback(() => {
+    return subscribe(buildFilters("newer"));
+  }, [subscribe, buildFilters]);
+
+  useEffect(() => {
+    const handleRef = { current: null as SubscriptionHandle | null };
+    const interval = setInterval(() => {
+      handleRef.current?.unsubscribe();
+      handleRef.current = pollForNew();
+    }, 60_000);
+
+    return () => {
+      clearInterval(interval);
+      handleRef.current?.unsubscribe();
+    };
+  }, [pollForNew]);
+
+  const visibleEvents = useMemo(() => events, [events]);
+
+  useEffect(() => {
+    if (events.length === 0) {
+      oldestNoteTimestampRef.current = null;
+      oldestPollTimestampRef.current = null;
+      return;
+    }
+
+    const oldestNote = events
+      .filter((event) => event.kind === KIND_NOTE)
+      .reduce<number | null>((oldest, event) => {
+        return oldest == null || event.created_at < oldest ? event.created_at : oldest;
+      }, null);
+    const oldestPoll = events
+      .filter((event) => event.kind === KIND_POLL)
+      .reduce<number | null>((oldest, event) => {
+        return oldest == null || event.created_at < oldest ? event.created_at : oldest;
+      }, null);
+
+    oldestNoteTimestampRef.current = oldestNote;
+    oldestPollTimestampRef.current = oldestPoll;
+  }, [events]);
+
+  useEffect(() => {
+    if (visibleEvents.length === 0) return;
+    requestReportCheck(visibleEvents.map((event) => event.id));
+    requestUserReportCheck(visibleEvents.map((event) => event.pubkey));
+  }, [visibleEvents, requestReportCheck, requestUserReportCheck]);
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <UnifiedFeed
+          data={visibleEvents}
+          loading={loadingInitial}
+          loadingMore={loadingMore}
+          refreshing={refreshing}
+          onEndReached={loadMore}
+          onRefresh={refreshFeed}
+          newItemCount={pendingEvents.length}
+          onShowNewItems={showNewEvents}
+          newItemLabel="posts"
+          computeItemKey={(_, event) => event.id}
+          itemContent={(_, event) => <MixedFeedItem event={event} />}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default MixedFeed;

--- a/src/components/Login/LoginModal.tsx
+++ b/src/components/Login/LoginModal.tsx
@@ -53,6 +53,7 @@ export const LoginModal: React.FC<Props> = ({ open, onClose }) => {
   useBackClose(open, onClose);
 
   useEffect(() => {
+    if (!isAndroidNative()) return;
     const initialize = async () => {
       const result = await NostrSignerPlugin.getInstalledSignerApps();
       setInstalledSigners(result.apps);

--- a/src/components/SidePane/index.tsx
+++ b/src/components/SidePane/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import HowToVoteIcon from "@mui/icons-material/HowToVote";
+import DynamicFeedIcon from "@mui/icons-material/DynamicFeed";
 import TagIcon from "@mui/icons-material/Tag";
 import ArticleIcon from "@mui/icons-material/Article";
 import BookIcon from "@mui/icons-material/MenuBook";
@@ -25,6 +26,11 @@ import { useSubNav } from "../../contexts/SubNavContext";
 // feed is currently mounted. Active state is read from localStorage so we can
 // show the correct selection even for feeds that aren't mounted yet.
 const MOBILE_SUB_ITEMS: Record<string, { key: string; label: string }[]> = {
+  all: [
+    { key: "global", label: "Global" },
+    { key: "following", label: "Following" },
+    { key: "webOfTrust", label: "Web of Trust" },
+  ],
   polls: [
     { key: "global", label: "Global" },
     { key: "following", label: "Following" },
@@ -52,6 +58,7 @@ const MOBILE_SUB_ITEMS: Record<string, { key: string; label: string }[]> = {
 };
 
 const FEED_STORAGE_KEYS: Record<string, string> = {
+  all: "pollerama:mixedSource",
   polls: "pollerama:pollSource",
   notes: "pollerama:lastNotesTab",
   topics: "pollerama:lastTopicsTab",
@@ -60,6 +67,7 @@ const FEED_STORAGE_KEYS: Record<string, string> = {
 };
 
 const FEED_DEFAULT_SUB: Record<string, string> = {
+  all: "global",
   polls: "global",
   notes: "discover",
   topics: "interests",
@@ -68,6 +76,7 @@ const FEED_DEFAULT_SUB: Record<string, string> = {
 };
 
 const feedOptions: { value: string; label: string; Icon: SvgIconComponent }[] = [
+  { value: "all",          label: "All",          Icon: DynamicFeedIcon },
   { value: "polls",        label: "Polls",        Icon: HowToVoteIcon },
   { value: "topics",       label: "Topics",       Icon: TagIcon },
   { value: "notes",        label: "Notes",        Icon: ArticleIcon },


### PR DESCRIPTION
## Summary

- Fixes : #44 
- Added a new mixed **All** feed at `/feeds/all` that combines regular notes (`kind:1`) and polls (`kind:1068`) in one timeline.
- Added **All** to sidebar navigation and preserved source filters (**Global**, **Following**, **Web of Trust**) for mixed feed browsing.
- Fixed web login crash by guarding Android signer discovery in `LoginModal`.
- Exposed explicit creation paths from All feed FAB:
  - **Create note**
  - **Create poll**

## What this covers for issue : 

- Show regular kind 1 notes with comments/likes/zaps
- Render tagged events inside notes
- Preview URLs client-side
- Allow creating regular notes and polls
- Mixed feed for notes + polls
- Surface existing functionality through reachable UI

## Demo screenshots

### 1. mixed notes + polls visible in **All** feed
<img width="1868" height="926" alt="image" src="https://github.com/user-attachments/assets/5913149e-7874-4319-900b-b0debc0c5854" />

### 2. note interactions (comments/likes/zaps)
<img width="1868" height="926" alt="image" src="https://github.com/user-attachments/assets/880c4cf0-6f25-4fa2-bdf1-877c4362fb6f" />

### 3. tagged/referenced event rendered inline
<img width="1866" height="928" alt="image" src="https://github.com/user-attachments/assets/c1c3d3a9-2edf-434f-90b7-5c99d04a503e" />

### 4.  URL preview card rendered in note content
<img width="1868" height="926" alt="image" src="https://github.com/user-attachments/assets/0b4eae29-f33f-4d45-8c95-7503343d0ae3" />

### 5. Create note / Create poll - explicit creation paths from All feed
<img width="1866" height="928" alt="image" src="https://github.com/user-attachments/assets/e1880e87-8a0e-4d9e-8455-f9f61783c171" />
