### PR TITLE
fix: prevent like/emoji reaction crashes from signer mismatch and relay publish errors

### DIFF
--- a/src/components/Common/Likes/likes.tsx
+++ b/src/components/Common/Likes/likes.tsx
@@ -9,7 +9,7 @@ import { useRelays } from "../../../hooks/useRelays";
 import { useUserContext } from "../../../hooks/useUserContext";
 import { useNotification } from "../../../contexts/notification-context";
 import { NOTIFICATION_MESSAGES } from "../../../constants/notifications";
-import { pool } from "../../../singletons";
+import { waitForPublish } from "../../../utils/publish";
 
 interface LikesProps {
   pollEvent: Event;
@@ -56,17 +56,25 @@ const Likes: React.FC<LikesProps> = ({ pollEvent }) => {
       return;
     }
 
-    const event: EventTemplate = {
-      content: emoji,
-      kind: 7,
-      tags: [["e", pollEvent.id, relays[0]]],
-      created_at: Math.floor(Date.now() / 1000),
-    };
+    try {
+      const event: EventTemplate = {
+        content: emoji,
+        kind: 7,
+        tags: [["e", pollEvent.id, relays[0]]],
+        created_at: Math.floor(Date.now() / 1000),
+      };
 
-    const finalEvent = await signEvent(event, user.privateKey);
-    pool.publish(relays, finalEvent!);
-    addEventToMap(finalEvent!);
-    setShowPicker(false);
+      const finalEvent = await signEvent(event, user.privateKey);
+      const publishResult = await waitForPublish(relays, finalEvent);
+      if (!publishResult.ok) {
+        throw new Error("No relay accepted reaction");
+      }
+      addEventToMap(finalEvent);
+      setShowPicker(false);
+    } catch (error) {
+      console.error("Failed to publish reaction", error);
+      showNotification(NOTIFICATION_MESSAGES.REACTION_PUBLISH_FAILED, "error");
+    }
   };
 
   useEffect(() => {

--- a/src/components/Login/LoginModal.tsx
+++ b/src/components/Login/LoginModal.tsx
@@ -54,8 +54,13 @@ export const LoginModal: React.FC<Props> = ({ open, onClose }) => {
 
   useEffect(() => {
     const initialize = async () => {
-      const result = await NostrSignerPlugin.getInstalledSignerApps();
-      setInstalledSigners(result.apps);
+      if (!isAndroidNative()) return;
+      try {
+        const result = await NostrSignerPlugin.getInstalledSignerApps();
+        setInstalledSigners(result.apps);
+      } catch (error) {
+        console.warn("Failed to load installed Android signers", error);
+      }
     };
     initialize();
   }, []);

--- a/src/constants/notifications.ts
+++ b/src/constants/notifications.ts
@@ -31,6 +31,7 @@ export const NOTIFICATION_MESSAGES = {
   LOGIN_TO_COMMENT: "Login To Comment",
   LOGIN_TO_ZAP: "Log In to send zaps!",
   LOGIN_TO_REPOST: "Login to repost!",
+  REACTION_PUBLISH_FAILED: "Failed to publish reaction. Please try again.",
 
   // Event creation
   EMPTY_NOTE_CONTENT: "Note content cannot be empty.",

--- a/src/singletons/Signer/SignerManager.ts
+++ b/src/singletons/Signer/SignerManager.ts
@@ -19,7 +19,7 @@ import { DEFAULT_IMAGE_URL } from "../../utils/constants";
 import { ANONYMOUS_USER_NAME, User } from "../../contexts/user-context";
 import { pool } from "..";
 import { createLocalSigner } from "./LocalSigner";
-import { isNative } from "../../utils/platform";
+import { isAndroidNative, isNative } from "../../utils/platform";
 import {
   getLegacyNsec,
   removeLegacyNsec,
@@ -119,6 +119,8 @@ class SignerManager {
   }
 
   async loginWithNip55(packageName: string, cachedPubkey?: string) {
+    if (!isAndroidNative()) throw new Error("NIP-55 login only allowed on Android");
+
     const signer = createNIP55Signer(packageName, cachedPubkey);
     const pubkey = await signer.getPublicKey();
 
@@ -174,20 +176,35 @@ class SignerManager {
     }
 
     const activePubkey = getActiveAccountPubkey();
-    const accountToActivate =
+    const preferredAccount =
       (activePubkey ? this.accounts.find((a) => a.pubkey === activePubkey) : null) ??
       this.accounts[0];
 
-    // Pre-populate user from cache for instant display while signer initialises
-    if (accountToActivate.userData) {
-      this.user = buildUser(accountToActivate);
+    const accountsToTry = [
+      preferredAccount,
+      ...this.accounts.filter((a) => a.pubkey !== preferredAccount.pubkey),
+    ];
+
+    let restored = false;
+    for (const account of accountsToTry) {
+      // Pre-populate user from cache for instant display while signer initialises
+      if (account.userData) {
+        this.user = buildUser(account);
+      }
+      try {
+        await this.activateAccount(account);
+        setActiveAccountPubkey(account.pubkey);
+        restored = true;
+        break;
+      } catch (e) {
+        console.error(`Signer restore failed for ${account.loginMethod}:`, e);
+      }
     }
 
-    try {
-      await this.activateAccount(accountToActivate);
-      setActiveAccountPubkey(accountToActivate.pubkey);
-    } catch (e) {
-      console.error("Signer restore failed:", e);
+    if (!restored) {
+      this.signer = null;
+      this.user = null;
+      removeActiveAccountPubkey();
     }
 
     this.notify();
@@ -362,6 +379,7 @@ class SignerManager {
         break;
       }
       case "nip55": {
+        if (!isAndroidNative()) throw new Error("NIP-55 is only supported on Android");
         const pkgName =
           account.nip55PackageName ??
           (isNative ? await getNip55PkgForAccount(account.pubkey) : null);


### PR DESCRIPTION
## Summary
This PR fixes a crash that occurred when reacting (like/emoji) in dev web sessions.

## Root Cause
1. In some sessions, an Android-only signer path could be reached outside Android.
2. Reaction publish failures from relays (rejected/failed publish promises) were not fully handled in the reaction flow, so errors bubbled up as uncaught runtime exceptions.

## Changes
- Hardened reaction publish flow to handle relay failures safely and avoid uncaught crashes.
- Added explicit Android-only guardrails around NIP-55 signer usage.
- Made login modal signer-app discovery platform-safe (Android-only guarded call).
- Added user-facing notification message for reaction publish failure.


## Validation
- Reproduced the issue before fix in dev.
- Verified post-fix behavior by retesting like/emoji flow.
- Build passes successfully.

## Test Plan
- [x] React with emoji on web dev build
- [x] React with like button on web dev build
- [x] Confirm app does not crash on relay/signing failure path
- [x] Confirm successful reactions still publish and render as expected
- [x] Run production build successfully