### PR TITLE
Fix Settings page rendering dark in light mode

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -30,21 +30,22 @@ export function buildTheme(
           mode: "dark",
           primary: { main: darkPrimary },
           secondary: { main: "#bdbdbc" },
-          background: { default: darkBg },
+          background: { default: darkBg, paper: darkBg },
         },
       },
       light: {
         palette: {
           primary: { main: lightPrimary },
           secondary: { main: "#bdbdbc" },
-          background: { default: lightBg },
+          background: { default: lightBg, paper: lightBg },
         },
       }
     },
     palette: {
+      mode: "light",
       primary: { main: lightPrimary },
       secondary: { main: "#bdbdbc" },
-      background: { default: "#000000" },
+      background: { default: lightBg, paper: lightBg },
     },
     components: {
       MuiCssBaseline: {


### PR DESCRIPTION
## Summary
- Fix incorrect MUI fallback theme background that caused `Settings` to appear dark in light mode.
- Set fallback `palette.mode` to `light` and align `background.default`/`background.paper` with `lightBg`.

## Test
- Switch to **Light** mode in Appearance settings.
- Open **Settings** and verify background/text contrast is correct.

## Demo
[Screencast from 2026-04-24 23-47-35.webm](https://github.com/user-attachments/assets/b1a368ec-2d7f-41b8-a95a-c4dd24aed668)
