### PR TITLE
Add issues write permission to build workflow permissions

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  issues: write
 
 jobs:
   resolve-pr:

--- a/.github/workflows/build-debug-ios.yml
+++ b/.github/workflows/build-debug-ios.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  issues: write
 
 jobs:
   resolve-pr:


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow permissions to include write access to issues in both the Android and iOS build workflows.

## Key Changes
- Added `issues: write` permission to `.github/workflows/build-debug-apk.yml`
- Added `issues: write` permission to `.github/workflows/build-debug-ios.yml`

## Details
These permission changes enable the build workflows to write to issues, which may be necessary for workflows to create or update issue comments, create issue labels, or perform other issue-related operations as part of the build process.

https://claude.ai/code/session_011bVgFZsVgZcjVThozM95xg