### PR TITLE
feat: comprehensive profile editing and posting from profile 

### DIFF
--- a/src/components/Feed/CreateFAB.tsx
+++ b/src/components/Feed/CreateFAB.tsx
@@ -7,7 +7,15 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useFeedActions } from "../../contexts/FeedActionsContext";
 import { DraggableCorner } from "../Common/DraggableCorner";
 
-const CreateFAB: React.FC = () => {
+interface CreateFABProps {
+  extraActions?: {
+    icon: React.ReactNode;
+    name: string;
+    onClick: () => void;
+  }[];
+}
+
+const CreateFAB: React.FC<CreateFABProps> = ({ extraActions = [] }) => {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
@@ -77,6 +85,18 @@ const CreateFAB: React.FC = () => {
             onClick={handleRefresh}
             sx={actionSx}
           />
+          {extraActions.map((action, index) => (
+            <SpeedDialAction
+              key={`extra-action-${index}`}
+              icon={action.icon}
+              tooltipTitle={action.name}
+              onClick={() => {
+                setOpen(false);
+                action.onClick();
+              }}
+              sx={actionSx}
+            />
+          ))}
           <SpeedDialAction
             icon={<AddIcon />}
             tooltipTitle="Create"

--- a/src/components/Header/BlossomSettings.tsx
+++ b/src/components/Header/BlossomSettings.tsx
@@ -12,7 +12,7 @@ import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import {
   BLOSSOM_SERVER_KEY,
-  DEFAULT_BLOSSOM_SERVER,
+  DEFAULT_BLOSSOM_SERVERS,
 } from "../../services/blossomService";
 
 const PRESET_SERVERS = [
@@ -27,7 +27,7 @@ const PRESET_SERVERS = [
 const CUSTOM_VALUE = "custom";
 
 function getCurrentServer(): string {
-  return localStorage.getItem(BLOSSOM_SERVER_KEY) || DEFAULT_BLOSSOM_SERVER;
+  return localStorage.getItem(BLOSSOM_SERVER_KEY) || DEFAULT_BLOSSOM_SERVERS[0];
 }
 
 function isPreset(url: string): boolean {

--- a/src/components/Profile/ProfileEditModal.tsx
+++ b/src/components/Profile/ProfileEditModal.tsx
@@ -1,0 +1,248 @@
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  CircularProgress,
+  IconButton,
+  InputAdornment,
+  Avatar,
+  Typography,
+} from "@mui/material";
+import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
+import { User } from "../../contexts/user-context";
+import { useUserContext } from "../../hooks/useUserContext";
+import { signerManager } from "../../singletons/Signer/SignerManager";
+import { useNotification } from "../../contexts/notification-context";
+import { uploadToBlossom, getBlossomServer } from "../../services/blossomService";
+import { signEvent } from "../../nostr";
+
+interface ProfileEditModalProps {
+  open: boolean;
+  onClose: () => void;
+  userProfile: User | null;
+}
+
+export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
+  open,
+  onClose,
+  userProfile,
+}) => {
+  const { user } = useUserContext();
+  const { showNotification } = useNotification();
+  const [loading, setLoading] = useState(false);
+
+  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [about, setAbout] = useState("");
+  const [picture, setPicture] = useState("");
+  const [banner, setBanner] = useState("");
+  const [website, setWebsite] = useState("");
+  const [nip05, setNip05] = useState("");
+  const [lud16, setLud16] = useState("");
+
+  useEffect(() => {
+    if (open && userProfile) {
+      setName(userProfile.name || "");
+      setDisplayName(userProfile.display_name || "");
+      setAbout(userProfile.about || "");
+      setPicture(userProfile.picture || "");
+      setBanner(userProfile.banner || "");
+      setWebsite(userProfile.website || "");
+      setNip05(userProfile.nip05 || "");
+      setLud16(userProfile.lud16 || "");
+    }
+  }, [open, userProfile]);
+
+  const [uploadingField, setUploadingField] = useState<"picture" | "banner" | null>(null);
+
+  const handleImageUpload = async (file: File, field: "picture" | "banner") => {
+    setUploadingField(field);
+    try {
+      const url = await uploadToBlossom(
+        file,
+        getBlossomServer(),
+        (template) => signEvent(template, user?.privateKey)
+      );
+      if (field === "picture") {
+        setPicture(url);
+      } else {
+        setBanner(url);
+      }
+      showNotification("Image uploaded successfully!", "success");
+    } catch (err) {
+      showNotification(
+        "Upload failed: " + (err instanceof Error ? err.message : String(err)),
+        "error"
+      );
+    } finally {
+      setUploadingField(null);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      await signerManager.publishKind0({
+        pubkey: user.pubkey,
+        name,
+        display_name: displayName,
+        about,
+        picture,
+        banner,
+        website,
+        nip05,
+        lud16,
+      });
+      showNotification("Profile updated successfully!");
+      
+      // Delay slightly so the relays can propagate, then notify the SignerManager to refresh cache
+      setTimeout(() => {
+        signerManager.afterLogin(user.pubkey);
+      }, 1000);
+      
+      onClose();
+    } catch (err) {
+      console.error("Failed to update profile:", err);
+      showNotification(
+        "Failed to update profile: " + (err instanceof Error ? err.message : String(err)),
+        "error"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Edit Profile</DialogTitle>
+      <DialogContent dividers>
+        <Box display="flex" flexDirection="column" gap={2}>
+          <TextField
+            label="Name / Username"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            size="small"
+            placeholder="e.g. alice"
+          />
+          <TextField
+            label="Display Name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            fullWidth
+            size="small"
+            placeholder="e.g. Alice Nakamoto"
+          />
+          <TextField
+            label="About"
+            value={about}
+            onChange={(e) => setAbout(e.target.value)}
+            fullWidth
+            multiline
+            rows={3}
+            size="small"
+          />
+          <Box display="flex" flexDirection="column" gap={1}>
+            <Typography variant="body2" color="text.secondary">Profile Picture</Typography>
+            <Box display="flex" flexDirection="row" gap={2} alignItems="center">
+              <Avatar src={picture} sx={{ width: 64, height: 64 }} />
+              <Button
+                component="label"
+                variant="outlined"
+                startIcon={uploadingField === "picture" ? <CircularProgress size={20} /> : <PhotoCameraIcon />}
+                disabled={uploadingField === "picture"}
+              >
+                Upload Picture
+                <input
+                  type="file"
+                  hidden
+                  accept="image/*"
+                  onChange={(e) => {
+                    if (e.target.files?.[0]) handleImageUpload(e.target.files[0], "picture");
+                    e.target.value = "";
+                  }}
+                />
+              </Button>
+            </Box>
+          </Box>
+
+          <Box display="flex" flexDirection="column" gap={1}>
+            <Typography variant="body2" color="text.secondary">Banner Image</Typography>
+            <Box
+              sx={{
+                width: "100%",
+                height: 120,
+                borderRadius: 1,
+                background: banner ? `url(${banner}) center/cover no-repeat` : "#e0e0e0",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                border: "1px dashed #ccc",
+              }}
+            >
+              <Button
+                component="label"
+                variant="contained"
+                startIcon={uploadingField === "banner" ? <CircularProgress size={20} /> : <PhotoCameraIcon />}
+                disabled={uploadingField === "banner"}
+                sx={{
+                  backgroundColor: "rgba(0,0,0,0.6)",
+                  "&:hover": { backgroundColor: "rgba(0,0,0,0.8)" },
+                }}
+              >
+                Upload Banner
+                <input
+                  type="file"
+                  hidden
+                  accept="image/*"
+                  onChange={(e) => {
+                    if (e.target.files?.[0]) handleImageUpload(e.target.files[0], "banner");
+                    e.target.value = "";
+                  }}
+                />
+              </Button>
+            </Box>
+          </Box>
+          <TextField
+            label="Website"
+            value={website}
+            onChange={(e) => setWebsite(e.target.value)}
+            fullWidth
+            size="small"
+            placeholder="https://..."
+          />
+          <TextField
+            label="NIP-05 Identifier"
+            value={nip05}
+            onChange={(e) => setNip05(e.target.value)}
+            fullWidth
+            size="small"
+            placeholder="name@domain.com"
+          />
+          <TextField
+            label="Lightning Address (LUD-16)"
+            value={lud16}
+            onChange={(e) => setLud16(e.target.value)}
+            fullWidth
+            size="small"
+            placeholder="name@wallet.com"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={loading} color="inherit">
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={loading} variant="contained">
+          {loading ? <CircularProgress size={24} /> : "Save Profile"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/Profile/ProfileEditModal.tsx
+++ b/src/components/Profile/ProfileEditModal.tsx
@@ -8,8 +8,6 @@ import {
   TextField,
   Box,
   CircularProgress,
-  IconButton,
-  InputAdornment,
   Avatar,
   Typography,
 } from "@mui/material";
@@ -86,18 +84,32 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
 
   const handleSave = async () => {
     if (!user) return;
+
+    const cleanNip05 = nip05.trim();
+    const cleanLud16 = lud16.trim();
+
+    if (cleanNip05 && !cleanNip05.includes("@")) {
+      showNotification("NIP-05 identifier must contain an '@' symbol (e.g. name@domain.com).", "error");
+      return;
+    }
+
+    if (cleanLud16 && !cleanLud16.includes("@")) {
+      showNotification("Lightning Address (LUD-16) must contain an '@' symbol (e.g. name@wallet.com).", "error");
+      return;
+    }
+
     setLoading(true);
     try {
       await signerManager.publishKind0({
         pubkey: user.pubkey,
-        name,
-        display_name: displayName,
-        about,
-        picture,
-        banner,
-        website,
-        nip05,
-        lud16,
+        name: name.trim(),
+        display_name: displayName.trim(),
+        about: about.trim(),
+        picture: picture.trim(),
+        banner: banner.trim(),
+        website: website.trim(),
+        nip05: cleanNip05,
+        lud16: cleanLud16,
       });
       showNotification("Profile updated successfully!");
       

--- a/src/components/Profile/ProfilePage.tsx
+++ b/src/components/Profile/ProfilePage.tsx
@@ -39,7 +39,11 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { useNotification } from "../../contexts/notification-context";
 import { Nip05Badge } from "../Common/Nip05Badge";
 import { TextWithImages } from "../Common/Parsers/TextWithImages";
-
+import EditIcon from "@mui/icons-material/Edit";
+import LinkIcon from "@mui/icons-material/Link";
+import { FeedActionsProvider } from "../../contexts/FeedActionsContext";
+import CreateFAB from "../Feed/CreateFAB";
+import { ProfileEditModal } from "./ProfileEditModal";
 interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
@@ -74,6 +78,7 @@ const ProfilePage: React.FC = () => {
   const [pubkey, setPubkey] = useState<string | null>(null);
   const [profile, setProfile] = useState<any>(null);
   const [tabValue, setTabValue] = useState(0);
+  const [editModalOpen, setEditModalOpen] = useState(false);
   const [followsYou, setFollowsYou] = useState(false);
   const [showContactListWarning, setShowContactListWarning] = useState(false);
   const [pendingFollowKey, setPendingFollowKey] = useState<string | null>(null);
@@ -322,10 +327,11 @@ const ProfilePage: React.FC = () => {
   const isOwnProfile = user?.pubkey === pubkey;
 
   return (
-    <Box
-      ref={scrollContainerRef}
-      maxWidth={800}
-      mx="auto"
+    <FeedActionsProvider>
+      <Box
+        ref={scrollContainerRef}
+        maxWidth={800}
+        mx="auto"
       sx={{
         px: 2,
         py: { xs: 2, sm: 4 },
@@ -430,43 +436,53 @@ const ProfilePage: React.FC = () => {
           </Box>
 
           {/* Action buttons */}
-          {!isOwnProfile && user && (
-            <Box
-              sx={{
-                display: "flex",
-                gap: 1,
-                mt: 2,
-                justifyContent: { xs: "center", sm: "flex-start" },
-              }}
-            >
-              {user.follows?.includes(pubkey) ? (
-                <Button
-                  variant="contained"
-                  size="small"
-                  startIcon={<CheckCircleIcon />}
-                  disableElevation
-                >
-                  Following
-                </Button>
-              ) : (
-                <Button
-                  variant="contained"
-                  size="small"
-                  onClick={addToContacts}
-                >
-                  {followsYou ? "Follow Back" : "Follow"}
-                </Button>
-              )}
+          <Box
+            sx={{
+              display: "flex",
+              gap: 1,
+              mt: 2,
+              justifyContent: { xs: "center", sm: "flex-start" },
+            }}
+          >
+            {isOwnProfile ? (
               <Button
                 variant="outlined"
                 size="small"
-                startIcon={<MailIcon />}
-                onClick={() => navigate(`/messages/${npub}`)}
+                onClick={() => setEditModalOpen(true)}
               >
-                Message
+                Edit Profile
               </Button>
-            </Box>
-          )}
+            ) : user ? (
+              <>
+                {user.follows?.includes(pubkey) ? (
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<CheckCircleIcon />}
+                    disableElevation
+                  >
+                    Following
+                  </Button>
+                ) : (
+                  <Button
+                    variant="contained"
+                    size="small"
+                    onClick={addToContacts}
+                  >
+                    {followsYou ? "Follow Back" : "Follow"}
+                  </Button>
+                )}
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<MailIcon />}
+                  onClick={() => navigate(`/messages/${npub}`)}
+                >
+                  Message
+                </Button>
+              </>
+            ) : null}
+          </Box>
 
           {/* Bio */}
           {profile?.about && (
@@ -476,6 +492,31 @@ const ProfilePage: React.FC = () => {
                 <TextWithImages content={profile.about} />
               </Typography>
             </>
+          )}
+
+          {/* Website */}
+          {profile?.website && (
+            <Box sx={{ mt: 1, display: "flex", alignItems: "center", gap: 0.5 }}>
+              <LinkIcon fontSize="small" color="action" />
+              <Typography
+                variant="body2"
+                component="a"
+                href={
+                  profile.website.startsWith("http")
+                    ? profile.website
+                    : `https://${profile.website}`
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  color: "primary.main",
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
+                {profile.website.replace(/^https?:\/\//, "")}
+              </Typography>
+            </Box>
           )}
 
           {/* Stats + Rate */}
@@ -590,7 +631,30 @@ const ProfilePage: React.FC = () => {
           </Button>
         </DialogActions>
       </Dialog>
-    </Box>
+      </Box>
+
+      {/* FAB with custom Profile actions */}
+      <CreateFAB
+        extraActions={
+          isOwnProfile
+            ? [
+                {
+                  icon: <EditIcon />,
+                  name: "Edit Profile",
+                  onClick: () => setEditModalOpen(true),
+                },
+              ]
+            : []
+        }
+      />
+
+      {/* Profile Edit Modal */}
+      <ProfileEditModal
+        open={editModalOpen}
+        onClose={() => setEditModalOpen(false)}
+        userProfile={profile}
+      />
+    </FeedActionsProvider>
   );
 };
 

--- a/src/contexts/user-context.tsx
+++ b/src/contexts/user-context.tsx
@@ -8,7 +8,12 @@ import { signerManager, StoredAccount } from "../singletons/Signer/SignerManager
 
 export type User = {
   name?: string;
+  display_name?: string;
   picture?: string;
+  banner?: string;
+  website?: string;
+  nip05?: string;
+  lud16?: string;
   pubkey: string;
   privateKey?: string;
   follows?: string[];

--- a/src/services/blossomService.ts
+++ b/src/services/blossomService.ts
@@ -2,11 +2,16 @@ import { EventTemplate } from "nostr-tools";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { bytesToHex } from "@noble/hashes/utils.js";
 
-export const DEFAULT_BLOSSOM_SERVER = "https://blossom.primal.net";
+export const DEFAULT_BLOSSOM_SERVERS = [
+  "https://blossom.primal.net",
+  "https://nostr.build"
+];
 export const BLOSSOM_SERVER_KEY = "pollerama:blossom-server";
 
-export function getBlossomServer(): string {
-  return localStorage.getItem(BLOSSOM_SERVER_KEY) || DEFAULT_BLOSSOM_SERVER;
+export function getBlossomServer(): string[] {
+  const custom = localStorage.getItem(BLOSSOM_SERVER_KEY);
+  if (custom) return [custom, ...DEFAULT_BLOSSOM_SERVERS.filter(s => s !== custom)];
+  return DEFAULT_BLOSSOM_SERVERS;
 }
 
 async function sha256Hex(file: File): Promise<string> {
@@ -24,13 +29,13 @@ async function sha256Hex(file: File): Promise<string> {
  * Upload a file to a Blossom server (BUD-01).
  *
  * @param file     - The file to upload
- * @param server   - Blossom server base URL (e.g. "https://blossom.primal.net")
+ * @param servers  - Array of Blossom server base URLs
  * @param signer   - Signs the kind-24242 auth event
  * @returns        - The public URL of the uploaded blob
  */
 export async function uploadToBlossom(
   file: File,
-  server: string,
+  servers: string | string[],
   signer: (template: EventTemplate) => Promise<any>
 ): Promise<string> {
   const hash = await sha256Hex(file);
@@ -49,23 +54,36 @@ export async function uploadToBlossom(
   });
 
   const authToken = btoa(JSON.stringify(authEvent));
-  const endpoint = server.replace(/\/$/, "") + "/upload";
+  const serverList = Array.isArray(servers) ? servers : [servers];
+  let lastError: Error | null = null;
 
-  const res = await fetch(endpoint, {
-    method: "PUT",
-    headers: {
-      Authorization: `Nostr ${authToken}`,
-      "Content-Type": file.type || "application/octet-stream",
-    },
-    body: file,
-  });
+  for (const server of serverList) {
+    const endpoint = server.replace(/\/$/, "") + "/upload";
 
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Blossom upload failed (${res.status}): ${body}`);
+    try {
+      const res = await fetch(endpoint, {
+        method: "PUT",
+        headers: {
+          Authorization: `Nostr ${authToken}`,
+          "Content-Type": file.type || "application/octet-stream",
+        },
+        body: file,
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`Blossom upload failed on ${server} (${res.status}): ${body}`);
+      }
+
+      const data = await res.json();
+      if (!data.url) throw new Error(`Blossom server ${server} returned no URL`);
+      return data.url as string;
+    } catch (err) {
+      console.warn(`Failed to upload to Blossom server: ${server}`, err);
+      lastError = err instanceof Error ? err : new Error(String(err));
+      // Continue to next server
+    }
   }
 
-  const data = await res.json();
-  if (!data.url) throw new Error("Blossom server returned no URL");
-  return data.url as string;
+  throw lastError || new Error("All Blossom upload attempts failed.");
 }

--- a/src/singletons/Signer/SignerManager.ts
+++ b/src/singletons/Signer/SignerManager.ts
@@ -101,7 +101,12 @@ function buildUserFromAccount(account: PackageStoredAccount): User {
   return {
     pubkey: account.pubkey,
     name: cached?.name ?? ANONYMOUS_USER_NAME,
+    display_name: cached?.display_name,
     picture: cached?.picture ?? DEFAULT_IMAGE_URL,
+    banner: cached?.banner,
+    website: cached?.website,
+    nip05: cached?.nip05,
+    lud16: cached?.lud16,
     about: cached?.about,
   };
 }
@@ -337,15 +342,24 @@ class SignerManager {
         `publishKind0: active signer pubkey ${signerPubkey} does not match target ${user.pubkey}`,
       );
     }
+    
+    // Build profile object including extended fields if they exist
+    const profileContent: Record<string, any> = {
+      name: user.name,
+      about: user.about || "",
+      picture: user.picture || "",
+    };
+    if (user.display_name) profileContent.display_name = user.display_name;
+    if (user.banner) profileContent.banner = user.banner;
+    if (user.website) profileContent.website = user.website;
+    if (user.nip05) profileContent.nip05 = user.nip05;
+    if (user.lud16) profileContent.lud16 = user.lud16;
+
     const kind0Event: EventTemplate = {
       kind: 0,
       created_at: Math.floor(Date.now() / 1000),
       tags: [],
-      content: JSON.stringify({
-        name: user.name,
-        about: user.about || "",
-        picture: user.picture || "",
-      }),
+      content: JSON.stringify(profileContent),
     };
     const signed = await signer.signEvent(kind0Event);
     pool.publish(defaultRelays, signed);
@@ -605,7 +619,12 @@ class SignerManager {
       const parsed = parseProfileContent(kind0, pubkey);
       setCachedUserData(pubkey, {
         name: parsed.name,
+        display_name: parsed.display_name,
         picture: parsed.picture,
+        banner: parsed.banner,
+        website: parsed.website,
+        nip05: parsed.nip05,
+        lud16: parsed.lud16,
         about: parsed.about,
       });
       // Refresh exposed user; the signer.onChange callback already set

--- a/src/singletons/Signer/userProfileCache.ts
+++ b/src/singletons/Signer/userProfileCache.ts
@@ -11,7 +11,12 @@ const KEY = "pollerama:userProfileCache";
 
 export type CachedUserData = {
   name?: string;
+  display_name?: string;
   picture?: string;
+  banner?: string;
+  website?: string;
+  nip05?: string;
+  lud16?: string;
   about?: string;
 };
 


### PR DESCRIPTION
@abh3po 
- Added full extended Nostr profile metadata support (banner, website, nip05, lud16, display_name).
- Created a `ProfileEditModal` for publishing comprehensive `kind: 0` metadata events.
- Replaced manual URL text inputs for avatars and banners with direct Blossom image upload buttons and visual previews.
- Integrated the "Edit Profile" action into the Profile page header and a floating dialer (SpeedDial).
- Upgraded `blossomService` with automatic fallback server iteration (defaults to Primal, falls back to nostr.build) for robust media uploads.
- Added website link rendering directly beneath the bio on user profiles.

https://github.com/user-attachments/assets/9fd547c5-abd8-47e5-bdfe-65b2c3d93d97

